### PR TITLE
Updated config.js - change release notes order

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -17,13 +17,13 @@ module.exports = {
       {
         title: 'Release notes',
         children: [
-          '/release-notes/8.3-beta',
-          '/release-notes/8.3-rc',
-          '/release-notes/8.3',
-          '/release-notes/8.4-beta',
-          '/release-notes/8.4-beta-arm',
+          '/release-notes/8.4-arm',
           '/release-notes/8.4',
-          '/release-notes/8.4-arm'
+          '/release-notes/8.4-beta-arm',
+          '/release-notes/8.4-beta',
+          '/release-notes/8.3',
+          '/release-notes/8.3-rc',
+          '/release-notes/8.3-beta'
         ]
       },
       {


### PR DESCRIPTION
As discussed in chat channel, PR to change release order. New releases on top