### PR TITLE
Adjust the recommended free disk space to reflect current mirror usage

### DIFF
--- a/docs/Mirrors.md
+++ b/docs/Mirrors.md
@@ -10,8 +10,8 @@ help us with this. The current list of public mirrors can be found on the
 
 You can create a public AlmaLinux mirror in 6 easy steps:
 
-1. Make sure that you have enough free space: 300GB is the absolute minimum
-   but we recommend reserving at least 500GB.
+1. Make sure that you have enough free space: 500GB is the absolute minimum
+   but we recommend reserving at least 700GB.
 2. Synchronize with the official AlmaLinux mirror via rsync:  
    ```shell
    /usr/bin/rsync -avSH -f 'R .~tmp~' --delete-delay --delay-updates rsync://rsync.repo.almalinux.org/almalinux/ /almalinux/dir/on/your/server/


### PR DESCRIPTION
As per [this](https://chat.almalinux.org/almalinux/pl/43huhwkxhb8fbpi6nn9486si7c) message in MatterMost the recommended free disk size for mirrors is outdated.

The current size is roughly 480GB~ (using hard links). 