### PR TITLE
fix spelling error

### DIFF
--- a/docs/sigs/Build-System.md
+++ b/docs/sigs/Build-System.md
@@ -1,5 +1,5 @@
 ---
-title: 'Buid System SIG'
+title: 'Build System SIG'
 ---
 
 # Build System SIG


### PR DESCRIPTION
Build System title reads "Buid System" This is a spelling correction