### PR TITLE
remove the deprecated download links

### DIFF
--- a/docs/release-notes/8.3-beta.md
+++ b/docs/release-notes/8.3-beta.md
@@ -1,7 +1,7 @@
 ---
-title: '8.3 beta'
+title: '8.3 Beta'
 ---
-# AlmaLinux 8.3 beta release notes
+# AlmaLinux 8.3 Beta release notes
 
 The release code name: Purple [Manul](https://en.wikipedia.org/wiki/Pallas%27s_cat).
 
@@ -17,11 +17,11 @@ Use this version to thoroughly test your workloads and report any unintended fea
 
 There are three installation ISO images available:
 
-[AlmaLinux-8.3-beta-1-x86_64-boot.iso](https://repo.almalinux.org/almalinux/8.3-beta/isos/x86_64/AlmaLinux-8.3-beta-1-x86_64-boot.iso) - a single network installation CD image that downloads packages over the Internet.
+`AlmaLinux-8.3-beta-1-x86_64-boot.iso` - a single network installation CD image that downloads packages over the Internet.
 
-[AlmaLinux-8.3-beta-1-x86_64-minimal.iso](https://repo.almalinux.org/almalinux/8.3-beta/isos/x86_64/AlmaLinux-8.3-beta-1-x86_64-minimal.iso) - a minimal self-containing DVD image that makes possible offline installation.
+`AlmaLinux-8.3-beta-1-x86_64-minimal.iso` - a minimal self-containing DVD image that makes possible offline installation.
 
-[AlmaLinux-8.3-beta-1-x86_64-dvd1.iso](https://repo.almalinux.org/almalinux/8.3-beta/isos/x86_64/AlmaLinux-8.3-beta-1-x86_64-dvd1.iso) - a full installation DVD image that contains mostly all AlmaLinux packages. We don't really recommend using it unless you need to set up and use AlmaLinux on a machine without internet access.
+`AlmaLinux-8.3-beta-1-x86_64-dvd1.iso` - a full installation DVD image that contains mostly all AlmaLinux packages. We don't really recommend using it unless you need to set up and use AlmaLinux on a machine without internet access.
 
 Download a preferable ISO image and verify its checksum. Here is an example for GNU/Linux:
 


### PR DESCRIPTION
the download links on 8.3 beta page are broken. the files seem deprecated. removed the links.