### PR TITLE
Build and deploy from master branch only

### DIFF
--- a/.github/workflows/deploy-gh_pages.yml
+++ b/.github/workflows/deploy-gh_pages.yml
@@ -1,6 +1,9 @@
 
 name: Deploy to GitHub Pages
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I realized that we're deploying the wiki anytime a push event happens in the repo, even when pushing to a branch different from master. As an example of it, look [here](https://github.com/AlmaLinux/wiki/pull/155/checks)

I assume we only want to run CI when pushing to master, hence this tiny PR 