### PR TITLE
Fix and clarify the output of `oscap oval eval`

### DIFF
--- a/docs/documentation/openscap-guide-for-9.md
+++ b/docs/documentation/openscap-guide-for-9.md
@@ -332,7 +332,7 @@ Definition oval:org.almalinux.alsa:def:20221728: false
 Evaluation done
 ```
 
-If the patch has been applied to the system - the output shows the *true* flag. If not - you see the *false* flag.
+A result of *false* means that the patch has been applied. A result of *true* means that the system is vulnerable and the patch is yet to be applied.
 
 Run the following command to generate the HTML report to view in a browser:
 

--- a/docs/documentation/openscap-guide.md
+++ b/docs/documentation/openscap-guide.md
@@ -270,7 +270,7 @@ Definition oval:org.almalinux.alsa:def:20224769: false
 ...
 Evaluation done.
 ```
-If the patch has been applied to the system - the output shows the *true* flag. If not - you see the *false* flag.
+A result of *false* means that the patch has been applied. A result of *true* means that the system is vulnerable and the patch is yet to be applied.
 
 * Run the following command to generate the HTML report to view in a browser:
 ```


### PR DESCRIPTION
The statement `If the patch has been applied to the system - the output shows the *true* flag. If not - you see the *false* flag.` has the logic mixed up. It is the other way around - false is good, true is bad.