### PR TITLE
Nginx link update Howto.md

### DIFF
--- a/docs/Howto.md
+++ b/docs/Howto.md
@@ -6,7 +6,7 @@ title: 'Howto Guides'
 ## Installation Guides
 - [ionCube Loader](https://cloud7.news/how-tos/how-to-install-ioncube-loader-in-almalinux/) 
 - [Varnish](https://cloud7.news/how-tos/how-to-install-varnish-on-almalinux/) 
-- [Nginx](https://cloud7.news/how-tos/how-to-install-nginx-on-almalinux-rocky-linux-centos-rhel/)
+- [Nginx](https://orcacore.com/install-nginx-web-server-almalinux-9/)
 - [cPanel](https://cloud7.news/how-tos/how-to-install-cpanel/)
 - [Foreman](https://www.how2shout.com/linux/how-to-install-foreman-on-rocky-or-almalinux-8/)  
 - [phpMyAdmin](https://wiki.crowncloud.net/?How_to_Install_phpMyAdmin_on_AlmaLinux_8)


### PR DESCRIPTION
The old link (https://cloud7.news/how-tos/how-to-install-nginx-on-almalinux-rocky-linux-centos-rhel/) is broken changed to another howto link -> https://orcacore.com/install-nginx-web-server-almalinux-9/