### PR TITLE
Added instructions for installing EPEL and RPM Fusion.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,7 +1,20 @@
+
 module.exports = {
   title: 'AlmaLinux Wiki',
   description: 'AlmaLinux OS Documentation',
-  head: [
+  head: [ ['script', {}, `
+	  var _paq = window._paq = window._paq || [];
+	  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+	  _paq.push(['trackPageView']);
+	  _paq.push(['enableLinkTracking']);
+	  (function() {
+	    var u="https://matomo.almalinux.org/";
+	    _paq.push(['setTrackerUrl', u+'matomo.php']);
+	    _paq.push(['setSiteId', '5']);
+	    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+	    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+	  })();
+`],
     ['link', { rel: "shortcut icon", type: 'image/png', href: "/images/logo.png"}],
   ],
   base: '/',
@@ -14,119 +27,236 @@ module.exports = {
       { text: 'Bugs', link: 'https://bugs.almalinux.org/' }
     ],
     sidebar: [
-      '/',
-      {
-        title: 'Release Notes',
-        path: '/release-notes/',
-        children: [
-          '/release-notes/9.2',
-          '/release-notes/8.8',
-          '/release-notes/9.1',
-          '/release-notes/8.7',
-          '/release-notes/9.2-beta',
-          '/release-notes/8.8-beta',
-          '/release-notes/9.0',
-          '/release-notes/8.6',
-          '/release-notes/9.1-beta',
-          '/release-notes/8.7-beta',
-          '/release-notes/9.0-beta',
-          '/release-notes/8.6-beta',
-          '/release-notes/8.5-ppc',
-          '/release-notes/8.5',
-          '/release-notes/8.5-beta-ppc',
-          '/release-notes/8.5-beta',
-          '/release-notes/8.4-arm',
-          '/release-notes/8.4',
-          '/release-notes/8.4-beta-arm',
-          '/release-notes/8.4-beta',
-          '/release-notes/8.3',
-          '/release-notes/8.3-rc',
-          '/release-notes/8.3-beta'
-        ]
-      },
-      {
-        title: 'Documentation',
-        children: [
-          '/documentation/installation-guide',
-          '/documentation/migration-guide',
-          '/documentation/openscap-guide',
-          '/documentation/openscap-guide-for-9',
-          '/documentation/oval-streams',
-          '/documentation/building-packages-guide',
-          '/documentation/raspberry-pi',
-          '/documentation/wsl',
-          '/documentation/errata',
-          '/documentation/sbom-guide',
-          '/documentation/epel-and-rpmfusion'
-        ]
-      },
-      {
-        title: 'Cloud',
-        children: [
-          '/cloud/AWS',
-          '/cloud/Azure',
-          '/cloud/Google',
-          '/cloud/Generic-cloud',
-          '/cloud/Generic-cloud-on-local',
-          '/cloud/OpenNebula',
-          '/cloud/OCI'
-        ]
-      },
-      {
-        title: 'Containers',
-        children: [
-          'containers/docker-images'
-        ]
-      },
-      '/LiveMedia',
-      {
-        title: 'Special interest groups',
-        path: '/sigs/',
-        children: [
-          '/sigs/Core',
-          '/sigs/Infrastructure',
-          '/sigs/Cloud',
-          '/sigs/Build-System',
-          '/sigs/LiveMedia',
-          '/sigs/Migration',
-	  '/sigs/ProcessForCreatingNewSIG',
-        ]
-      },
-      {
-        title: 'Repositories',
-        path: '/repos/',
-        children:[
-           '/repos/AlmaLinux',
-           '/repos/CentOS',
-           '/repos/Extras',
-        ]
-      },
-      {
+     {
+        title: 'About',
+        path: '/',
+     },
+	'/alesco',
+     {
+          title: 'Contribute',
+          children: [
+            '/Contribute',
+            '/Contribute-to-Documentation',
+            '/Mirrors',
+            '/Contribute-to-Testing',
+            '/Help-translating-site',
+            {
+              title: 'Special interest groups (SIGs)',
+              path: '/sigs/',
+              children: [
+                '/sigs/Build-System',
+                '/sigs/Cloud',
+                '/sigs/Core',
+                '/sigs/HPCandAI',
+                '/sigs/Infrastructure',
+                '/sigs/LiveMedia',
+			      {
+			        title: 'The Marketing SIG',
+			        path: '/sigs/Marketing',
+			        children: [
+			         '/sigs/marketing/indico',
+			        ]
+			     },
+                '/sigs/Migration',
+                '/sigs/ProcessForCreatingNewSIG'
+              ]
+           },
+          ]
+     },
+     {
         title: 'Development',
         children: [
-          '/development/Packaging',
+          '/documentation/building-packages-guide',
+          '/development/building-almalinux-iso-locally',
           '/development/Modified-packages',
-          '/development/openQA'
+          '/development/Packaging',
+          {
+            title: "Private Keys",
+			children: [
+             '/development/private-keys/secure-boot'
+            ]
+          }
         ]
-      },
-      '/Mirrors',
-      {
-        title: 'ELevate Project',
-        path: '/elevate/',
+     },
+     {
+        title: 'Documentation',
         children: [
-          '/elevate/ELevate-quickstart-guide',
-          '/elevate/ELevate-testing-guide',
-          '/elevate/Contribution-guide',
-          '/elevate/ELevate-frequent-issues'
-        ]
+            '/Comparison',
+            '/FAQ',
+            '/Howto',
+            {
+                title: 'openQA Guide',
+                path: '/development/openQA',
+            },
+            {
+                title: 'Howto Series',
+                path: '/series/',
+                children: [
+		              '/series/LAMP-server',
+                  {
+                      title: "Nginx Series",
+                      path: '/series/nginx/',
+                      children: [
+                              '/series/nginx/NginxSeriesA01',
+                              '/series/nginx/NginxSeriesA02R8',
+                              '/series/nginx/NginxSeriesA02R91',
+                              '/series/nginx/NginxSeriesA02R92',
+                              '/series/nginx/NginxSeriesA03',
+                              '/series/nginx/NginxSeriesA04P1',
+                      ]
+                  },
+                  {
+                      title: "System Series",
+                      path: '/series/system/',
+                      children: [
+                              '/series/system/SystemSeriesA01',
+                              '/series/system/SystemSeriesA02',
+                              '/series/system/SystemSeriesA03',
+                              '/series/system/SystemSeriesA03R8',
+                              '/series/system/SystemSeriesA03R9',
+                              '/series/system/SystemSeriesA04',
+                              '/series/system/SystemSeriesA05',
+                      ]
+                  }
+              ]
+            },
+            {
+                title: 'Release Notes',
+                path: '/release-notes/',
+                children: [
+                  '/release-notes/9.4',
+                  '/release-notes/8.10',
+                  '/release-notes/9.3',
+                  '/release-notes/8.9',
+                  '/release-notes/9.4-beta',
+                  '/release-notes/8.10-beta',
+                  '/release-notes/9.2',
+                  '/release-notes/8.8',
+                  '/release-notes/9.3-beta',
+                  '/release-notes/8.9-beta',
+                  '/release-notes/9.1',
+                  '/release-notes/8.7',
+                  '/release-notes/9.2-beta',
+                  '/release-notes/8.8-beta',
+                  '/release-notes/9.0',
+                  '/release-notes/8.6',
+                  '/release-notes/9.1-beta',
+                  '/release-notes/8.7-beta',
+                  '/release-notes/9.0-beta',
+                  '/release-notes/8.6-beta',
+                  '/release-notes/8.5-ppc',
+                  '/release-notes/8.5',
+                  '/release-notes/8.5-beta-ppc',
+                  '/release-notes/8.5-beta',
+                  '/release-notes/8.4-arm',
+                  '/release-notes/8.4',
+                  '/release-notes/8.4-beta-arm',
+                  '/release-notes/8.4-beta',
+                  '/release-notes/8.3',
+                  '/release-notes/8.3-rc',
+                  '/release-notes/8.3-beta'
+                ]
+          },
+          {
+                title: 'Security Guides',
+                path: '/documentation/guides',
+                children: [
+                  '/documentation/openscap-guide',
+                  '/documentation/openscap-guide-for-9',
+                  '/documentation/oval-streams',
+                  '/documentation/sbom-guide',
+                  '/documentation/errata',
+                ]
+            },
+         ]
       },
-      '/FAQ',
-      '/Comparison',
-      '/Howto',
-      '/Contribute',
-      '/gsoc',
-      '/Election2022',
-	  '/Transparency'
+      {
+        title: 'Installation',
+        children: [
+         '/documentation/installation-guide',
+         '/documentation/after-installation-guide',
+         '/documentation/wsl',
+          {
+            title: 'Live Media',
+            path: '/LiveMedia',
+          },
+          '/documentation/raspberry-pi',
+          {
+            title: 'Cloud Images',
+            path : '/cloud',
+            children: [
+              {
+                title: 'Generic Cloud (Cloud-init)',
+                path: '/cloud',
+                children: [
+                  '/cloud/Generic-cloud',
+                  '/cloud/Generic-cloud-on-local',
+                ]
+              },
+              {
+                title: 'AWS',
+                path : '/cloud',
+                children: [
+                  '/cloud/AWS',
+                  '/cloud/EC2-instance-connect',
+                ],
+              },
+              '/cloud/Azure',
+              '/cloud/Google',
+              '/cloud/OCI',
+              '/cloud/OpenNebula',
+            ]
+        },
+        {
+            title: 'Containers',
+            path: '/containers',
+            children: [
+              '/containers/docker-images'
+            ]
+        },
+        {
+            title: 'Repositories',
+            path: '/repos/',
+            children:[
+              '/repos/AlmaLinux',
+              '/repos/CentOS',
+              '/repos/Extras',
+              '/repos/Synergy',
+            ]
+           },
+         ]
+      },
+      {
+         title: 'Migration',
+         path: '/migration',
+         children: [
+           '/documentation/migration-guide',
+           {
+              title: 'ELevate Project',
+              path: '/elevate/',
+              children: [
+                '/elevate/ELevate-quickstart-guide',
+                '/elevate/ELevating-CentOS7-to-AlmaLinux-9',
+                '/elevate/ELevating-CentOS6-to-CentOS7',
+                '/elevate/ELevate-offline-guide',
+                '/elevate/ELevate-testing-guide',
+                '/elevate/ELevate-NG-testing-guide',
+                '/elevate/ELevate-frequent-issues',
+                '/elevate/Contribution-guide',
+              ]
+           },
+         ]
+      },
+      {
+        title: 'The Foundation',
+        children: [
+         '/Transparency',
+         '/Election2022',
+         '/election2023',
+         '/gsoc',
+        ]
+     },
+    '/Help-and-Support',
     ],
     // AlmaLinux organization on GitHub
     repo: 'AlmaLinux/',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -56,7 +56,8 @@ module.exports = {
           '/documentation/raspberry-pi',
           '/documentation/wsl',
           '/documentation/errata',
-          '/documentation/sbom-guide'
+          '/documentation/sbom-guide',
+          '/documentation/epel-and-rpmfusion'
         ]
       },
       {

--- a/docs/Howto.md
+++ b/docs/Howto.md
@@ -4,6 +4,7 @@ title: 'Howto Guides'
 # AlmaLinux Howto Guides
 
 ## Installation Guides
+- [EPEL and RPM Fusion](/docs/documentation/epel-and-rpmfusion.md)
 - [ionCube Loader](https://cloud7.news/how-tos/how-to-install-ioncube-loader-in-almalinux/) 
 - [Varnish](https://cloud7.news/how-tos/how-to-install-varnish-on-almalinux/) 
 - [Nginx](https://orcacore.com/install-nginx-web-server-almalinux-9/)

--- a/docs/documentation/epel-and-rpmfusion.md
+++ b/docs/documentation/epel-and-rpmfusion.md
@@ -1,0 +1,45 @@
+---
+title: "Installing EPEL and RPM Fusion"
+---
+
+# Installing EPEL and RPM Fusion
+
+This guide describes how to install _Extra Packages for Enterprise Linux (EPEL)_ and _RPM Fusion_, two software repositories that contain software that is not included by AlmaLinux (like codecs).
+
+:::warning
+These third-party software repositories are not supported by AlmaLinux's [ELevate Project](../elevate/).
+:::
+
+## Step 1: Install EPEL. 
+Installing EPEL is required for RPM Fusion.
+1. Follow the instructions [described here](../repos/Extras.md) to install EPEL.
+
+	
+## Step 2: Install (and verify) the RPM Fusion GPG keys
+Downloading and verifying the RPM Fusion GPG keys ensures that the packages you install are from RPM Fusion and not altered (by accident or by malicious intent).
+1. Download the _distribution-gpg-keys_ package. 
+```bash
+$ sudo dnf install distribution-gpg-keys
+```
+- If you get a prompt to import a GPG key, compare the key you recived to [Fedora's package signing keys](https://fedoraproject.org/security/). Make sure the key on the webpage is the correct EPEL version as the one described on the userid, and make sure the fingerprints match.
+2. Import the RPM Fusion keys with `rpmkeys`
+```bash
+# RPM Fusion (free packages)
+$ sudo rpmkeys --import /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-el-$(rpm -E %rhel)
+# RPM Fusion (nonfree packages)
+$ sudo rpmkeys --import /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-el-$(rpm -E %rhel)
+```
+3. (Optional) Check that the GPG keys match the one on the [RPM Fusion keys page](https://rpmfusion.org/keys). (It is in the section labeled "Currently Used Keys".) Use the commands below to show the keys that were imported and compare them to the one in RPM Fusion.
+```bash
+# RPM Fusion (free packages)
+$ gpg --show-keys --with-fingerprint /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-el-$(rpm -E %rhel)
+# RPM Fusion (nonfree packages)
+$ gpg --show-keys --with-fingerprint /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-el-$(rpm -E %rhel)
+```
+
+## Step 3: Install RPM Fusion
+Enter the command below.
+```bash
+$ sudo dnf --setopt=localpkg_gpgcheck=1 install  https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm
+```
+If the installation fails, this may mean that the keys do not match. If this occurs, retry step 2.3 to see if you have the correct GPG keys. 

--- a/docs/documentation/epel-and-rpmfusion.md
+++ b/docs/documentation/epel-and-rpmfusion.md
@@ -7,7 +7,7 @@ title: "Installing EPEL and RPM Fusion"
 This guide describes how to install _Extra Packages for Enterprise Linux (EPEL)_ and _RPM Fusion_, two software repositories that contain software that is not included by AlmaLinux (like codecs).
 
 :::warning
-These third-party software repositories are not supported by AlmaLinux's [ELevate Project](../elevate/).
+These third-party software repositories may not be supported by AlmaLinux's [ELevate Project](../elevate/).
 :::
 
 ## Step 1: Install EPEL. 

--- a/docs/documentation/epel-and-rpmfusion.md
+++ b/docs/documentation/epel-and-rpmfusion.md
@@ -42,4 +42,4 @@ Enter the command below.
 ```bash
 $ sudo dnf --setopt=localpkg_gpgcheck=1 install  https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm
 ```
-If the installation fails, this may mean that the keys do not match. If this occurs, retry step 2.3 to see if you have the correct GPG keys. 
+If the installation fails, this may mean that the GPG keys imported earlier do not match the signiture of the RPM Fusion repositories. If this occurs, retry step 2.3 to see if you have the correct GPG keys. 

--- a/docs/repos/Extras.md
+++ b/docs/repos/Extras.md
@@ -27,7 +27,7 @@ During the installation process, you might get a prompt to install a GPG key. Co
 | ELRepo | # dnf install elrepo-release |
 
 ## RPM Fusion
-[RPM Fusion](https://rpmfusion.org/) provides software that RHEL and other Enterprise Linux distributions do not to ship (like software codecs).
+[RPM Fusion](https://rpmfusion.org/) provides software that RHEL and other Enterprise Linux distributions do not ship (like software codecs).
 
 | Repository | How to Enable |
 | --- | --- |

--- a/docs/repos/Extras.md
+++ b/docs/repos/Extras.md
@@ -10,7 +10,9 @@ EPEL packages are usually based on their Fedora counterparts and will never conf
 
 | Repository | How to Enable |
 | --- | --- |
-| EPEL | See the [EPEL Quickstart Guide](https://docs.fedoraproject.org/en-US/epel/#_quickstart) |
+| EPEL and CRB | # dnf install epel-release |
+
+For more detailed information see the [EPEL Quickstart Guide](https://docs.fedoraproject.org/en-US/epel/).
 
 :::tip
 During the installation process, you might get a prompt to install a GPG key. Compare the key to the "Primary key fingerprint" (see ["Verify the downloaded ISO image checksum:"](../documentation/installation-guide.md#iso-verification)) and if the fingerprints match, type "y" to continue.

--- a/docs/repos/Extras.md
+++ b/docs/repos/Extras.md
@@ -10,7 +10,11 @@ EPEL packages are usually based on their Fedora counterparts and will never conf
 
 | Repository | How to Enable |
 | --- | --- |
-| EPEL | # dnf install epel-release |
+| EPEL | See the [EPEL Quickstart Guide](https://docs.fedoraproject.org/en-US/epel/#_quickstart) |
+
+:::tip
+During the installation process, you might get a prompt to install a GPG key. Compare the key to the "Primary key fingerprint" (see ["Verify the downloaded ISO image checksum:"](../documentation/installation-guide.md#iso-verification)) and if the fingerprints match, type "y" to continue.
+:::
 
 ## The ELRepo Project
 
@@ -19,3 +23,10 @@ EPEL packages are usually based on their Fedora counterparts and will never conf
 | Repository | How to Enable |
 | --- | --- |
 | ELRepo | # dnf install elrepo-release |
+
+## RPM Fusion
+[RPM Fusion](https://rpmfusion.org/) provides software that RHEL and other Enterprise Linux distributions do not want to ship (like software codecs).
+
+| Repository | How to Enable |
+| --- | --- |
+| ELRepo | See _[Installing EPEL and RPM Fusion](../documentation/epel-and-rpmfusion.md)_ |

--- a/docs/repos/Extras.md
+++ b/docs/repos/Extras.md
@@ -27,7 +27,7 @@ During the installation process, you might get a prompt to install a GPG key. Co
 | ELRepo | # dnf install elrepo-release |
 
 ## RPM Fusion
-[RPM Fusion](https://rpmfusion.org/) provides software that RHEL and other Enterprise Linux distributions do not want to ship (like software codecs).
+[RPM Fusion](https://rpmfusion.org/) provides software that RHEL and other Enterprise Linux distributions do not to ship (like software codecs).
 
 | Repository | How to Enable |
 | --- | --- |


### PR DESCRIPTION
## What does this pull request do?

This pull request adds instructions for adding the EPEL and RPM Fusion software repositories, with GPG key verification.

## Why?

This pull request aims to make the process of installing several software repositories more clear for the end user.

The current documentation does not explain how to install EPEL in a clear manner (see https://github.com/AlmaLinux/wiki/issues/232). This pull request changes the instructions to the official quickstart guide on the Fedora project website.

In addition, there are no instructions on how to install RPMfusion (which provides additional packages) anywhere on the website. The RPMfusion website does have directions on how to install their repositories, but does not do it in a way where the user can verify the GPG signing key in an easy manner. This pull request adds instructions on how to install RPM Fusion as well as verifying the signing keys.

Also included is an guide on how to install both EPEL and RPM Fusion. This is at the bottom of the documentation section so that new users can find it.

fixes https://github.com/AlmaLinux/wiki/issues/232