### PR TITLE
Sig standardization proposal

### DIFF
--- a/docs/sigs/Build-System.md
+++ b/docs/sigs/Build-System.md
@@ -6,16 +6,27 @@ title: 'Build System SIG'
 
 The Build System Team is responsible for automating processes of building distribution and packages, testing packages, signing packages, and releasing them to public repositories.
 
+## How to Join
+
+Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
+
+**Where we chat**
+
 The Build System SIG uses the [SIG/Build System](https://chat.almalinux.org/almalinux/channels/build-system) chat channel for communication.
 
-## Deliverables:
+**Where and when we meet**
+
+Meetings are held regularly, including a daily standup. If you would like to join these meetings, join the channel and ask for an invite!
+
+## Activities, projects, and deliverables
+
 * [Build System project's documentation and issue tracker](https://github.com/AlmaLinux/build-system)
 * [Build System Web-Server](https://github.com/AlmaLinux/albs-web-server)
 * [Build System Build Node](https://github.com/AlmaLinux/albs-node)
 * [Build System Test System](https://github.com/AlmaLinux/alts)
 * [Build System Frontend](https://github.com/AlmaLinux/albs-frontend)
 
-## Help wanted:
+### Help wanted:
 
 * Add OpenStack backend driver support.
 * Improve OpenNebula backend driver support.
@@ -24,9 +35,8 @@ The Build System SIG uses the [SIG/Build System](https://chat.almalinux.org/alma
 * Add support for external test projects.
 
 ## SIG Members:
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release
-  engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the
-  company efforts on the AlmaLinux OS development and support.
+
+* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
   * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
   * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)
 * [Vasily Kleschov](mailto:vkleschov@cloudlinux.com) - Build System Team Lead.

--- a/docs/sigs/Cloud.md
+++ b/docs/sigs/Cloud.md
@@ -5,11 +5,19 @@ title: "Cloud SIG"
 
 The Cloud team is responsible for AlmaLinux OS container and cloud images.
 
-The Cloud SIG uses the [SIG/Cloud](https://chat.almalinux.org/almalinux/channels/sigcloud)
-chat channel for communication.
+## How to Join
 
+Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
 
-## Deliverables
+**Where we chat**
+
+The Cloud SIG uses the [SIG/Cloud](https://chat.almalinux.org/almalinux/channels/sigcloud) chat channel on [chat.almalinux.org](https://chat.almalinux.org) for communication.
+
+**Where and when we meet**
+
+We do not currently hold regular meetings, but work asynchronously in mattermost to accomplish our goals. 
+
+## Activities, projects, and deliverables
 
 * The AlmaLinux OS Docker/Podman images:
   [AlmaLinux/docker-images](https://github.com/AlmaLinux/docker-images).
@@ -23,8 +31,6 @@ chat channel for communication.
   [AlmaLinux/ks2rootfs](https://github.com/AlmaLinux/ks2rootfs).
 * OpenNebula addons repositories:
   [x86_64](https://repo.almalinux.org/almalinux/8/extras/x86_64/os/Packages/almalinux-release-opennebula-addons-1-1.el8.noarch.rpm) and [aarch64](https://repo.almalinux.org/almalinux/8/extras/aarch64/os/Packages/almalinux-release-opennebula-addons-1-1.el8.noarch.rpm)
-
-
 
 The pre-built AlmaLinux OS images are listed below:
 
@@ -41,7 +47,7 @@ The pre-built AlmaLinux OS images are listed below:
 | Vagrant boxes              | [app.vagrantup.com/almalinux](https://app.vagrantup.com/almalinux/) |
 
 
-## Help wanted
+### Help wanted
 
 * Vagrant + Parallels Desktop box maintainer.
 * Optimized images for Digital Ocean and other cloud providers.
@@ -51,7 +57,7 @@ The pre-built AlmaLinux OS images are listed below:
 * Technical writers for working on documentation.
 * DevOps engineers for setting up and maintaining the related infrastructure.
 
-If you can help, please join us at [Cloud SIG on Mattermost](https://chat.almalinux.org/almalinux/channels/sigcloud)
+If you can help, please join us at [SIG/Cloud on Mattermost](https://chat.almalinux.org/almalinux/channels/sigcloud)
 
 
 ## SIG members
@@ -59,8 +65,6 @@ If you can help, please join us at [Cloud SIG on Mattermost](https://chat.almali
 * [Elkhan Mammadli](mailto:elkhan.mammadli@protonmail.com) - Works on Qemu/Libvirt support.
   * Chat login: [lkhn](https://chat.almalinux.org/almalinux/messages/@lkhn)
   * GitHub profile: [LKHN](https://github.com/LKHN)
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release
-  engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the
-  company efforts on the AlmaLinux OS development and support.
+* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
   * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
   * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)

--- a/docs/sigs/Core.md
+++ b/docs/sigs/Core.md
@@ -3,15 +3,21 @@ title: "Core SIG"
 ---
 # Core SIG
 
-The Core team is responsible for the AlmaLinux OS distribution itself. This
-includes, but is not limited to building new distribution versions,
-delivering updates, core tooling development, and maintenance.
+The Core team is responsible for the AlmaLinux OS distribution itself. This includes, but is not limited to building new distribution versions, delivering updates, core tooling development, and maintenance.
 
-The Core SIG uses the [SIG/Core](https://chat.almalinux.org/almalinux/channels/sigcore)
-chat channel for communication.
+## How to Join
 
+Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
 
-## Deliverables
+**Where we chat**
+
+The Core SIG uses the [SIG/Core](https://chat.almalinux.org/almalinux/channels/sigcore) chat channel for communication.
+
+**Where and when we meet**
+
+We meet on Google Meet every other Tuesday at 16:00 UTC. If you would like to join, join the chat and ask for an invite!
+
+## Activities, projects, and deliverables
 
 * The AlmaLinux OS distribution.
 * The mirrors infrastructure: [AlmaLinux/mirrors](https://github.com/AlmaLinux/mirrors).
@@ -19,7 +25,7 @@ chat channel for communication.
 * Bug reports processing: [bugs.almalinux.org](https://bugs.almalinux.org/).
 
 
-## Help wanted
+### Help wanted
 
 * Technical writers for working on announcements, security bulletins, wiki
   articles and so on.
@@ -35,15 +41,12 @@ chat channel for communication.
 
 If you can help, please join us at [Core SIG on Mattermost](https://chat.almalinux.org/almalinux/channels/sigcore) 
 
-
 ## SIG members
 
 * [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - The AlmaLinux OS Architect.
   * Chat login: [alukoshko](https://chat.almalinux.org/almalinux/messages/@alukoshko)
   * GitHub profile: [andrewlukoshko](https://github.com/andrewlukoshko)
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release
-  engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the
-  company efforts on the AlmaLinux OS development and support.
+* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
   * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
   * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)
 * [Jack Aboutboul](mailto:jack@almalinux.org) - The AlmaLinux OS community manager.

--- a/docs/sigs/Infrastructure.md
+++ b/docs/sigs/Infrastructure.md
@@ -3,14 +3,21 @@ title: "Infrastructure SIG"
 ---
 # Infrastructure SIG
 
-The infrastructure team is responsible for maintaining the servers and services that keep AlmaLinux online and
-accessible to end users.
+The infrastructure team is responsible for maintaining the servers and services that keep AlmaLinux online and accessible to end users.
 
-The Infrastructure SIG uses the [Infrastructure](https://chat.almalinux.org/almalinux/channels/infrastructure)
-chat channel and the [Infrastructure mailing list](https://lists.almalinux.org/mailman3/lists/infra.lists.almalinux.org/) for communication.
+## How to Join
 
+Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
 
-## Deliverables
+**Where we chat**
+
+The Infrastructure SIG uses the [Infrastructure](https://chat.almalinux.org/almalinux/channels/infrastructure) chat channel and the [Infrastructure mailing list](https://lists.almalinux.org/mailman3/lists/infra.lists.almalinux.org/) for communication.
+
+**Where and when we meet**
+
+We don't currently hold regular meetings, but work asynchronously in mattermost to accomplish our goals. 
+
+## Activities, projects, and deliverables
 
 * Mirror infrastructure: [AlmaLinux/mirrors](https://github.com/AlmaLinux/mirrors)
 * Official mirrors:
@@ -33,13 +40,12 @@ chat channel and the [Infrastructure mailing list](https://lists.almalinux.org/m
   * [Bug Reports](https://bugs.almalinux.org)
 
 
-## Help wanted
+### Help wanted
 
 * Building Ansible playbooks for maintaining internal infrastructure.
-* TBD
+* much, much more.
 
-If you can help, please join us at [Infrastructure channel](https://chat.almalinux.org/almalinux/channels/infrastructure) 
-
+If you would like to help, please join us at [Infrastructure channel](https://chat.almalinux.org/almalinux/channels/infrastructure) 
 
 ## SIG members
 
@@ -49,9 +55,7 @@ If you can help, please join us at [Infrastructure channel](https://chat.almalin
 * [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - AlmaLinux OS Architect
   * Chat login: [alukoshko](https://chat.almalinux.org/almalinux/messages/@alukoshko)
   * GitHub profile: [andrewlukoshko](https://github.com/andrewlukoshko)
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release
-  engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the
-  company efforts on the AlmaLinux OS development and support.
+* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
   * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
   * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)
 * [Stepan Oksanichenko](mailto:soksanichenko@cloudlinux.com) - Package Evolution Service & Mirror Service Developer

--- a/docs/sigs/LiveMedia.md
+++ b/docs/sigs/LiveMedia.md
@@ -5,25 +5,29 @@ title: "Live Media SIG"
 
 The Live Media Team is responsible for AlmaLinux OS Live Media.
 
-The Live Media SIG uses the [SIG/LiveMedia](https://chat.almalinux.org/almalinux/channels/siglivemedia)
-chat channel for communication.
+## How to Join
 
+Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
 
-## Deliverables
+**Where we chat**
+
+The Live Media SIG uses the [SIG/LiveMedia](https://chat.almalinux.org/almalinux/channels/siglivemedia) chat channel for communication.
+
+**Where and when we meet**
+
+We do not currently hold regular meetings, but work asynchronously in mattermost to accomplish our goals.
+
+## Activities, projects, and deliverables
 
 * ISO images download link: [repo.almalinux.org/almalinux/8/live/x86_64](https://repo.almalinux.org/almalinux/8/live/x86_64/).
 * Build scripts and configuration files: [AlmaLinux/sig-livemedia](https://github.com/AlmaLinux/sig-livemedia).
 
-
-
-## Help wanted
+### Help wanted
 
 * Technical writers for working on documentation.
 * Design and automate test scenarios.
 
-
 If you can help, please join us at [Live Media SIG on Mattermost](https://chat.almalinux.org/almalinux/channels/siglivemedia) 
-
 
 ## SIG members
 

--- a/docs/sigs/Marketing.md
+++ b/docs/sigs/Marketing.md
@@ -42,6 +42,7 @@ Contributions take all kinds of shapes and sizes, and we welcome everyone! If yo
 * Content writers -- especially for the blog and social media
 * Website maintainers -- our Hugo migration is complete, but we need to clean it up
 * Graphic designers -- we have sticker ideas, but they aren't nearly as pretty as they could be!
+* Website translations -- accepted through [Weblate](https://hosted.weblate.org/projects/almalinux/website-backend/), automatically sent to the website repo for merging in. 
 
 We have tons of ideas and bugs on the [website repo](https://github.com/AlmaLinux/almalinux.org) and on [GitHub Projects](https://github.com/orgs/AlmaLinux/projects/5/views/1).
 

--- a/docs/sigs/Marketing.md
+++ b/docs/sigs/Marketing.md
@@ -37,7 +37,7 @@ Other efforts that we manage:
 
 Contributions take all kinds of shapes and sizes, and we welcome everyone! If you have expertise or time and would like to help us out, here are a few things that need help soon, and a place where you can find more information.
 
-* Mastodon automation - we use Sprout Social for scheduling ahead of tiem right now, but it doens't work with mastodon! 
+* Mastodon automation - we use Sprout Social for scheduling ahead of time right now, but it doesn't work with mastodon! 
 * Event management and staffing -- help us expand the number of events we can join by helping us staff events local to you!
 * Content writers -- especially for the blog and social media
 * Website maintainers -- our Hugo migration is complete, but we need to clean it up

--- a/docs/sigs/Marketing.md
+++ b/docs/sigs/Marketing.md
@@ -3,41 +3,76 @@ title: "Marketing SIG"
 ---
 # Marketing SIG
 
-The Marketing team is responsible for AlmaLinux marketing efforts, and we use the [Marketing](https://chat.almalinux.org/almalinux/channels/marketing)
-chat channel for communication on the AlmaLinux chat server.
+The Marketing team is responsible for AlmaLinux marketing efforts.
 
-Meetings are every other Friday on Google Meet at 3pm UTC. Join the Marketing channel on [chat.almalinux.org](chat.almalinux.org) and ask benny for the meeting invite!
+## How to Join
 
-## Deliverables
+Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
 
-* Event plans
-* Outreach efforts
-* End user "help me convince my team to use AlmaLinux" support
+**Where we chat**
 
-## Help wanted
+We use the [~Marketing](https://chat.almalinux.org/almalinux/channels/marketing) channel for communication on the AlmaLinux mattermost server.
 
-* Event staffers
-* Content writers (especially for the blog and social media)
-* Website maintainers
-* Graphic designers
+**Where/how we meet**
 
-## SIG members
+Meetings are every other Friday on Google Meet at 3pm UTC. Join the Marketing channel on [chat.almalinux.org](https://chat.almalinux.org/almalinux/channels/marketing) and ask benny for the meeting invite! Our meeting notes are kept in [Google drive](https://docs.google.com/document/d/1OK8mQSU-EucCT-VdFVOd87BECmVSXIKXkG7uhLubs9o/edit#heading=h.9ynhotw081jk).
 
-(titles are in the context of the Marketing SIG - these folks might also operate in other capacities elsewhere at AlmaLinux)
+### SIG members
 
-* [benny Vasquez](mailto:benny@almalinux.org) - Temporary committee lead
-* [Jack Aboutboul](mailto:jack@almalinux.org) - Community Manager/PR
-* [Jonathan Wright](mailto:jonathan@almalinux.org) - Events 
-* [Cody Robertson](mailto:crobertson@almalinux.org) - General Volunteer 
+These members share responsibilities between and among each other.
+
+* [benny Vasquez](mailto:benny@almalinux.org) - SIG leader
+* [Jack Aboutboul](mailto:jack@almalinux.org) - Member
+* [Jonathan Wright](mailto:jonathan@almalinux.org) - Member 
+* [Cody Robertson](mailto:crobertson@almalinux.org) - Member 
 
 We also have a variety of folks who help us with PR, social media, and website maintenance through submissions to chat or just PRs to the [website repo](https://github.com/AlmaLinux/almalinux.org).
 
+## Activities, projects, and deliverables
+
+Properties that we are responsible for:
+
+* [almalinux.org](https://almalinux.org)
+* [shop.almalinux.org](shop.almalinux.org)
+
+We also provide content for other properties as needed by other SIGs.
+
+Other efforts that we manage: 
+
+* Event plans
+* Outreach efforts
+* Social media management
+* Press efforts
+
+### Help wanted
+
+Contributions take all kinds of shapes and sizes, and we welcome everyone! If you have expertise or time and would like to help us out, here are a few things that need help soon, and a place where you can find more information.
+
+* Event staffers -- help us expand the number of events we can join by helping us staff events local to you!
+* Content writers -- especially for the blog and social media
+* Website maintainers -- our Hugo migration is complete, but we need to clean it up
+* Graphic designers -- we have sticker ideas, but they aren't nearly as pretty as they could be!
+
+We have tons of ideas and bugs on the [website repo](https://github.com/AlmaLinux/almalinux.org) and on [GitHub Projects](https://github.com/orgs/AlmaLinux/projects/5/views/1).
+
 ## Social Media Accounts
 
-We currently have a number of social media accounts that are managed by the SIG members.
+We currently have a number of social media accounts that are managed by the SIG members. 
+
+### Active accounts
+
+These accounts are actively monitored, updated, and managed by the SIG on a regular basis. 
 
 * [Mastodon (on fosstodon.org)](https://fosstodon.org/@almalinux) - password in Vaultwarden
 * [Twitter (x)](https://twitter.com/almalinux) - password in Vaultwarden
-* [Facebook](https://www.facebook.com/AlmaLinux/) - still tracking down admin rights
+* [Facebook](https://www.facebook.com/AlmaLinux/) - password in Vaultwarden
 * [LinkedIn](https://www.linkedin.com/company/almalinuxos/) - benny and Jack have 'owner' rights
+
+### Inactive (placeholder) accounts
+
+These accounts are only in place to keep the name owned by us, and to point folks to our active accounts.
+
 * [Youtube](https://www.youtube.com/@almalinux6891) - benny and Jack have 'owner' rights
+* [BlueSky](bsky.app/almalinux) - password in Vaultwarden
+
+

--- a/docs/sigs/Marketing.md
+++ b/docs/sigs/Marketing.md
@@ -15,18 +15,7 @@ We use the [~Marketing](https://chat.almalinux.org/almalinux/channels/marketing)
 
 **Where/how we meet**
 
-Meetings are every other Friday on Google Meet at 3pm UTC. Join the Marketing channel on [chat.almalinux.org](https://chat.almalinux.org/almalinux/channels/marketing) and ask benny for the meeting invite! Our meeting notes are kept in [Google drive](https://docs.google.com/document/d/1OK8mQSU-EucCT-VdFVOd87BECmVSXIKXkG7uhLubs9o/edit#heading=h.9ynhotw081jk).
-
-### SIG members
-
-These members share responsibilities between and among each other.
-
-* [benny Vasquez](mailto:benny@almalinux.org) - SIG leader
-* [Jack Aboutboul](mailto:jack@almalinux.org) - Member
-* [Jonathan Wright](mailto:jonathan@almalinux.org) - Member 
-* [Cody Robertson](mailto:crobertson@almalinux.org) - Member 
-
-We also have a variety of folks who help us with PR, social media, and website maintenance through submissions to chat or just PRs to the [website repo](https://github.com/AlmaLinux/almalinux.org).
+Meetings are every other Thursday on Google Meet at 9pm UTC. Join the Marketing channel on [chat.almalinux.org](https://chat.almalinux.org/almalinux/channels/marketing) and ask benny for the meeting invite! Our meeting notes are kept in [Google drive](https://docs.google.com/document/d/1OK8mQSU-EucCT-VdFVOd87BECmVSXIKXkG7uhLubs9o/edit#heading=h.9ynhotw081jk).
 
 ## Activities, projects, and deliverables
 
@@ -48,12 +37,24 @@ Other efforts that we manage:
 
 Contributions take all kinds of shapes and sizes, and we welcome everyone! If you have expertise or time and would like to help us out, here are a few things that need help soon, and a place where you can find more information.
 
-* Event staffers -- help us expand the number of events we can join by helping us staff events local to you!
+* Mastodon automation - we use Sprout Social for scheduling ahead of tiem right now, but it doens't work with mastodon! 
+* Event management and staffing -- help us expand the number of events we can join by helping us staff events local to you!
 * Content writers -- especially for the blog and social media
 * Website maintainers -- our Hugo migration is complete, but we need to clean it up
 * Graphic designers -- we have sticker ideas, but they aren't nearly as pretty as they could be!
 
 We have tons of ideas and bugs on the [website repo](https://github.com/AlmaLinux/almalinux.org) and on [GitHub Projects](https://github.com/orgs/AlmaLinux/projects/5/views/1).
+
+## SIG members
+
+These members share responsibilities between and among each other.
+
+* [benny Vasquez](mailto:benny@almalinux.org) - SIG leader
+* [Jack Aboutboul](mailto:jack@almalinux.org) - Member
+* [Jonathan Wright](mailto:jonathan@almalinux.org) - Member 
+* [Cody Robertson](mailto:crobertson@almalinux.org) - Member 
+
+We also have a variety of folks who help us with PR, social media, and website maintenance through submissions to chat or just PRs to the [website repo](https://github.com/AlmaLinux/almalinux.org).
 
 ## Social Media Accounts
 
@@ -74,5 +75,3 @@ These accounts are only in place to keep the name owned by us, and to point folk
 
 * [Youtube](https://www.youtube.com/@almalinux6891) - benny and Jack have 'owner' rights
 * [BlueSky](bsky.app/almalinux) - password in Vaultwarden
-
-

--- a/docs/sigs/Migration.md
+++ b/docs/sigs/Migration.md
@@ -16,16 +16,25 @@ What OSes can be converted:
 
 Migration from CentOS 7 to RHEL8 derivatives such as AlmaLinux, CentOS, EuroLinux, Rocky, Oracle is also in the Migration Team's duties.
 
+## How to Join
+
+Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
+
+**Where we chat**
+
 The Migration SIG uses the [SIG/Migration](https://chat.almalinux.org/almalinux/channels/migration) chat channel for communication.
 
-# Deliverables
+**Where and when we meet**
 
-* AlmaLinux Leapp patches at: [AlmaLinux/leapp-repository](https://github.com/AlmaLinux/leapp-repository/tree/almalinux).
-  Consider this is not a separated forked project.
+We do not currently hold regular meetings, but work asynchronously in mattermost to accomplish our goals.
+
+## Activities, projects, and deliverables
+
+* AlmaLinux Leapp patches at: [AlmaLinux/leapp-repository](https://github.com/AlmaLinux/leapp-repository/tree/almalinux). Consider this is not a separated forked project.
 * Static data files for Leapp utility: [AlmaLinux/leapp-data](https://github.com/AlmaLinux/leapp-data)
 * Package Evolution Service: [pes.almalinux.org](https://pes.almalinux.org)
 
-# Help wanted
+### Help wanted
 
 * Testing various configurations
 * Developing scripts for populating unsupported kernel modules and pci ids lists
@@ -33,14 +42,12 @@ The Migration SIG uses the [SIG/Migration](https://chat.almalinux.org/almalinux/
 
 If you can help, please join us at [Migration SIG on Mattermost](https://chat.almalinux.org/almalinux/channels/migration).
 
-# SIG members
+## SIG members
 
 * [Stepan Oksanichenko](mailto:soksanichenko@cloudlinux.com) - Package Evolution Service developer.
    * Chat login: [stepan_oksanichenko](https://chat.almalinux.org/almalinux/messages/@stepan_oksanichenko)
    * GitHub profile: [soksanichenko](https://github.com/soksanichenko)
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release
-  engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the
-  company efforts on the AlmaLinux OS development and support.
+* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
   * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
   * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)
 * [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - The AlmaLinux OS Architect.

--- a/docs/sigs/ProcessForCreatingNewSIG.md
+++ b/docs/sigs/ProcessForCreatingNewSIG.md
@@ -14,10 +14,12 @@ Once you have gathered a group (we recommend no fewer than 3, but that isn't tru
 
 ### 1. Write a proposal for the board
 
-To create a new SIG, a proposal must be submitted to and approved by the AlmaLinux OS Foundation Board. The proposal should include:
+To create a new SIG, a proposal must be submitted to and approved by the AlmaLinux OS Foundation Board. To create the proposal, clone this repo, make a copy of the [template](https://wiki.almalinux.org/sigs/sigproposaltemplate.html) file, title it for your SIG, and start filling things in! Once you are satisfied with the content of your proposal, submit a pull request to the wiki, and tag @bennyvasquez. She'll take a look and let you know if there are any concerns. 
+
+If none, she'll let you know the date of the board meeting at which your SIG proposal will be discussed! Members of the board or the community might comment and ask questions or provide feedback on your pull request ahead of the board meeting, so make sure to answer those questions as well as you can. At a minimum, your proposal should include:
 
 <ol type="a">
-  <li>A clear and concise title for the SIG.</li>
+  <li>A clear and concise name for the SIG.</li>
   <li>An overview of the SIG's objectives and goals.</li>
   <li>A list of initial members, including at least one SIG leader.</li>
   <li>A description of the SIG's intended activities and projects.</li>
@@ -25,47 +27,40 @@ To create a new SIG, a proposal must be submitted to and approved by the AlmaLin
   <li>Any known required resources, such as infrastructure or funding.</li>
 </ol>
 
+[template](https://wiki.almalinux.org/sigs/sigproposaltemplate.html)
+
 
 ### 2. Proposal Review
 
-Upon receiving a proposal, the AlmaLinux OS Foundation Board will review the submission to ensure it aligns with the project's goals and values. The review process includes:
+The job of the AlmaLinux OS Foundation Board in this process is to review the submission to ensure it aligns with the project's goals and values. The review process includes:
+
 <ol type="a">
   <li>Assessing the proposal's relevance to the AlmaLinux ecosystem.</li>
   <li>Evaluating the clarity and feasibility of the SIG's objectives and activities.</li>
-  <li>Reviewing the qualifications of the proposed SIG Chair and initial members.</li>
+  <li>Provide any insight or guidance that might be beneficial for the SIG.</li>
 </ol>
 
 
 ### 3. Feedback and Revision
 
-If the proposal requires modifications or additional information, the AlmaLinux OS Foundation Board will provide feedback to the proposers. The group of proposers will then have the opportunity to revise and resubmit the proposal, addressing the feedback provided.
+Though we hope to have provided all of the feedback ahead of time, if the board has additional thoughts about the proposal and requires modifications or additional information at the scheduled board meeting, the feedback will be provided to the proposers. The group of proposers will then have the opportunity to revise and resubmit the proposal, addressing the feedback provided.
 
 
 ### 4. Approval and Announcement
 
-Once the proposal has been reviewed and deemed acceptable, the AlmaLinux OS Foundation Board will formally approve the creation of the new SIG. The approval will be announced through appropriate communication channels, such as mailing lists, forums, and social media. The announcement will include:
+Once the proposal has been reviewed and deemed acceptable, the board will formally approve the creation of the new SIG, and the pull request will be merged into the wiki. The approval will be announced by the marketing SIG through appropriate communication channels, such as mailing lists, forums, and social media. The announcement will include:
+
 <ol type="a">
   <li>The title and objectives of the new SIG.</li>
-  <li>The names of the SIG Chair and initial members.</li>
-  <li>A link to the SIG's primary point of communication or wiki entry (if applicable).</li>
+  <li>A link to the SIG's wiki page.</li>
   <li>An invitation for interested community members to join the SIG.</li>
 </ol>
 
 
-### 5. SIG Formation
-
-Following the announcement, the new SIG will:
-<ol type="a">
-  <li>Establish a dedicated communication channel (e.g., mailing list, chat room, or forum) for members to collaborate and discuss SIG-related matters.</li>
-  <li>Create a public repository (if applicable) for storing and managing project resources and documentation.</li>
-  <li>Develop a roadmap and publish its goals in a publicly trackable way.</li>
-  <li>Assign tasks to SIG members, as applicable.</li>
-</ol>
-
-
-### 6. Reporting and Accountability
+### 5. Reporting and Accountability
 
 To maintain transparency and ensure progress towards the SIG's objectives, the SIG Chair will be responsible for:
+
 <ol type="a">
   <li>Providing regular status updates to the AlmaLinux OS Foundation Board.</li>
   <li>Ensuring that SIG activities adhere to the AlmaLinux project's guidelines and policies.</li>
@@ -88,9 +83,10 @@ To improve the integration of new SIGs within the AlmaLinux community, consider 
 
 ### A.2. SIG Decommissioning
 
-In the event a SIG becomes inactive, no longer serves its intended purpose, or does not align with the community's objectives, outline a process for decommissioning the SIG. This may include:
+In the event a SIG becomes inactive, no longer serves its intended purpose, or does not align with the community's objectives, the SIG may mark itself (or be marked) as inactive, or may be decommissioned. This may include:
+
 <ol type="a">
-  <li>Notifying the AlmaLinux OS Foundation Board of the intention to decommission the SIG.</li>
+  <li>Notifying the board and the community of the intention to decommission the SIG.</li>
   <li>Ensuring that all relevant documentation, resources, and knowledge are preserved and transferred to appropriate parties within the community.</li>
-  <li>Formally announcing the decommissioning of the SIG and providing a rationale for the decision.</li>
+  <li>Formally announcing the decommissioning of the SIG, updating the wiki page to reflect the decision and ideally providing a rationale for the decision.</li>
 </ol>

--- a/docs/sigs/ProcessForCreatingNewSIG.md
+++ b/docs/sigs/ProcessForCreatingNewSIG.md
@@ -2,29 +2,25 @@
 # The Process for Creating a New SIG* in the AlmaLinux Community 
 *Special Interest Group
 
+SIGs are the lifeblood for a healthy open source community, especially around an operating system. Joining a SIG is the first step that many newcomers to a community take, and standardizing the process around creating a SIG is important because it ensures that newcomers are met with similar information no matter which group they chose to start with. 
 
-## Abstract
+This document outlines the process and additional considerations for creating a new Special Interest Group (SIG) within the AlmaLinux OS community, fostering collaboration, innovation, and growth. This process aims to facilitate successful SIG creation and integration within the AlmaLinux ecosystem. SIGs are essential for bringing together individuals and organizations with common interests to work on specific projects, develop new features, or address particular issues within the AlmaLinux project. Incorporating insights from Fedora and CentOS, such as mentorship and collaboration with existing SIGs, periodic evaluation for continuous improvement, and guidelines for SIG decommissioning, this process is designed to help individuals and organizations contribute effectively to the continued success of the AlmaLinux project and shape its future.
 
-> This document outlines the process and additional considerations for creating a new Special Interest Group (SIG) within the AlmaLinux OS community, fostering collaboration, innovation, and growth. This process aims to facilitate successful SIG creation and integration within the AlmaLinux ecosystem. SIGs are essential for bringing together individuals and organizations with common interests to work on specific projects, develop new features, or address particular issues within the AlmaLinux project. Incorporating insights from Fedora and CentOS, such as mentorship and collaboration with existing SIGs, periodic evaluation for continuous improvement, and guidelines for SIG decommissioning, this process is designed to help individuals and organizations contribute effectively to the continued success of the AlmaLinux project and shape its future.
+### 0. Gauge interest
 
+If you have an idea and want to see if there is interest in that idea, the first step is to gather a group of folks together that might want to work on that thing. You can do that by asking in the [chat](https://chat.almalinux.org), sending an email to the [users mailing list](https://lists.almalinux.org/mailman3/lists/users.lists.almalinux.org/), and posting on the [forums](https://almalinux.discourse.group/). 
 
-## Scope
+Once you have gathered a group (we recommend no fewer than 3, but that isn't true for every effort), it's time to start getting things lined up!
 
-This process is applicable to any individual or organization within the AlmaLinux community who wishes to establish a new SIG.
+### 1. Write a proposal for the board
 
-
-## Procedure
-
-
-### 1. Proposal Submission
-
-To initiate the process of creating a new SIG, a proposal must be submitted to the AlmaLinux OS Foundation Board. The proposal should include:
+To create a new SIG, a proposal must be submitted to and approved by the AlmaLinux OS Foundation Board. The proposal should include:
 
 <ol type="a">
   <li>A clear and concise title for the SIG.</li>
   <li>An overview of the SIG's objectives and goals.</li>
-  <li>A list of initial members, including at least one SIG Chair.</li>
-  <li>A detailed description of the SIG's intended activities and projects.</li>
+  <li>A list of initial members, including at least one SIG leader.</li>
+  <li>A description of the SIG's intended activities and projects.</li>
   <li>A proposed timeline for achieving the SIG's initial objectives.</li>
   <li>Any known required resources, such as infrastructure or funding.</li>
 </ol>
@@ -75,8 +71,6 @@ To maintain transparency and ensure progress towards the SIG's objectives, the S
   <li>Ensuring that SIG activities adhere to the AlmaLinux project's guidelines and policies.</li>
   <li>Coordinating the SIG's communication and collaboration with other SIGs and the broader AlmaLinux community</li>
 </ol>
-
-## 
 
 
 ## Additional Considerations

--- a/docs/sigs/README.md
+++ b/docs/sigs/README.md
@@ -4,11 +4,7 @@ title: "Special interest groups"
 
 # Special interest groups
 
-Special interest groups (SIGs) are teams within the AlmaLinux OS community
-that are focused on specific topics. Each SIG has its own channel on our
-[Mattermost](https://mattermost.com/) chat server
-[chat.almalinux.org](https://chat.almalinux.org/).
-
+Special interest groups (SIGs) are teams within the AlmaLinux OS community that are focused on specific topics. Each SIG has its own channel on our [Mattermost](https://mattermost.com/) chat server [chat.almalinux.org](https://chat.almalinux.org/).
 
 The following SIGs are already established:
 

--- a/docs/sigs/README.md
+++ b/docs/sigs/README.md
@@ -4,7 +4,7 @@ title: "Special interest groups"
 
 # Special interest groups
 
-Special interest groups (SIGs) are teams within the AlmaLinux OS community that are focused on specific topics. Each SIG has its own channel on our [Mattermost](https://mattermost.com/) chat server [chat.almalinux.org](https://chat.almalinux.org/).
+Special interest groups (SIGs) are teams within the AlmaLinux OS community that are focused on specific topics. Each SIG has its own channel on our [Mattermost](https://mattermost.com/) chat server [chat.almalinux.org](https://chat.almalinux.org/), but may communicate and work in different ways. Each SIG's details are found in the pages below. 
 
 The following SIGs are already established:
 

--- a/docs/sigs/sigproposaltemplate.md
+++ b/docs/sigs/sigproposaltemplate.md
@@ -1,0 +1,43 @@
+---
+title: "name of SIG"
+---
+# name of SIG
+
+[insert the SIG's purpose here]
+
+## How to Join
+
+Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
+
+**Where we chat**
+
+We use $platform for communication. [ this should either be a link to the SIG chat room on mattermost, or the mailing list on lists.almalinux.org ]
+
+**Where and when we meet**
+
+Meetings are... [ this should be a general day/time/cadence, and indicate how one might join this meeting if they'd like ]
+
+### SIG members
+
+
+* [name](either email address or mattermost chat link) - Committee lead
+* [name](either email address or mattermost chat link) - member
+
+( you can also include additional information about other folks that help your SIG or are involved in some way here )
+
+## Activities, projects, and deliverables
+
+[ this should be the thing or list of things you expect to be responsible for ]
+
+### Help wanted
+
+Contributions take all kinds of shapes and sizes, and we welcome everyone! If you have expertise or time and would like to help us out, here are a few things that need help soon, and a place where you can find more information.
+
+[ either a list of things or a link to a project/task tracker should go here ]
+
+## Additional information for SIG application approval
+
+* Timeline for when you would like to get things rolling for this group, and how quickly you expect to see motion on your Activities, projects, and deliverables.
+* Any known resources (monetary or infrastructure) that you anticipate needing, and how they will be used.
+
+[ You can add anything additional you feel is important here as well ]

--- a/docs/sigs/sigproposaltemplate.md
+++ b/docs/sigs/sigproposaltemplate.md
@@ -15,15 +15,7 @@ We use $platform for communication. [ this should either be a link to the SIG ch
 
 **Where and when we meet**
 
-Meetings are... [ this should be a general day/time/cadence, and indicate how one might join this meeting if they'd like ]
-
-### SIG members
-
-
-* [name](either email address or mattermost chat link) - Committee lead
-* [name](either email address or mattermost chat link) - member
-
-( you can also include additional information about other folks that help your SIG or are involved in some way here )
+Meetings are... [ this should be a general day/time/cadence, and indicate how one might join this meeting if they'd like, or use "We do not currently hold regular meetings, but work asynchronously in mattermost to accomplish our goals." ]
 
 ## Activities, projects, and deliverables
 
@@ -34,6 +26,13 @@ Meetings are... [ this should be a general day/time/cadence, and indicate how on
 Contributions take all kinds of shapes and sizes, and we welcome everyone! If you have expertise or time and would like to help us out, here are a few things that need help soon, and a place where you can find more information.
 
 [ either a list of things or a link to a project/task tracker should go here ]
+
+## SIG members
+
+* [name](either email address or mattermost chat link) - Committee lead
+* [name](either email address or mattermost chat link) - member
+
+(you can also include additional information about other folks that help your SIG or are involved in some way here)
 
 ## Additional information for SIG application approval
 


### PR DESCRIPTION
One of the boundaries for folks who are new to AlmaLinux is a lack of standardization for onboarding new members to the SIGS. This PR has a lot of changes in it, but it boils down to:

* create a standardized SIG wiki page structure that each existing SIG would adopt (see the changes to the marketing SIG page for an example)
* update the process for creating new SIGs to reduce the work involved for standing up a new SIG, and remove as much of the "red tape" as possible. 