### PR TITLE
Replace LXD with Incus

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@
     <li><a href="https://www.reddit.com/r/AlmaLinux/">reddit.com/r/AlmaLinux</a> - Reddit Community</li>
     <li><a href="https://repo.almalinux.org/">repo.almalinux.org</a> - Public Package Repository</li>
     <li><a href="https://status.almalinux.org/">status.almalinux.org</a> - Public Status Page</li>
-    <li><b>Cloud Images </b>(and Sources) for AWS, Google Cloud, Generic/Cloud-Init, LXC/LXD</li>
+    <li><b>Cloud Images </b>(and Sources) for AWS, Google Cloud, Generic/Cloud-Init, LXC/Incus</li>
     <li><a href="https://github.com/AlmaLinux/cloud-images">AlmaLinux Cloud Images</a></li>
     <li><a href=cloud/AWS>Expanded documentation on AWS</a></li>
     <li><a href=cloud/Generic-cloud>Expanded documentation on Generic Cloud/Cloud-Init</a></li> 

--- a/docs/sigs/Cloud.md
+++ b/docs/sigs/Cloud.md
@@ -42,7 +42,7 @@ The pre-built AlmaLinux OS images are listed below:
 | Generic Cloud (cloud-init) | [wiki.almalinux.org/cloud/Generic-cloud.html](https://wiki.almalinux.org/cloud/Generic-cloud.html) |
 | OpenNebula                 | [wiki.almalinux.org/cloud/OpenNebula.html](https://wiki.almalinux.org/cloud/OpenNebula.html) |
 | Google Cloud               | [cloud.google.com/compute/docs/images#almalinux](https://cloud.google.com/compute/docs/images#almalinux) |
-| LXC/LXD                    | [images.linuxcontainers.org](https://images.linuxcontainers.org) |
+| LXC/Incus                  | [images.linuxcontainers.org](https://images.linuxcontainers.org) |
 | Quay                       | [quay.io/almalinuxorg](https://quay.io/almalinuxorg) |
 | Vagrant boxes              | [app.vagrantup.com/almalinux](https://app.vagrantup.com/almalinux/) |
 


### PR DESCRIPTION
Image server is starting to restrict LXD users. We should encourage our users to use Incus.

Related: AlmaLinux/almalinux.org#447