### PR TITLE
doc/Mirrors: fix example rsync command

### DIFF
--- a/docs/Mirrors.md
+++ b/docs/Mirrors.md
@@ -29,7 +29,7 @@ Use updated version of `rsync` with `xxhash` support.
 :::
 2. Synchronize with the official AlmaLinux mirror via `rsync`:  
    ```shell
-   /usr/bin/rsync -avSH -f 'R .~tmp~' --delete-delay --delay-updates rsync://rsync.repo.almalinux.org/almalinux/ /almalinux/dir/on/your/server/
+   /usr/bin/rsync -avSH --exclude='.~tmp~' --delete-delay --delay-updates rsync://rsync.repo.almalinux.org/almalinux/ /almalinux/dir/on/your/server/
    ```
    - The official tier0 rsync mirrors are in Atlanta, GA, USA, and Seattle, WA, USA.  We use geolocation-based DNS steering to send your traffic to the closest tier0 mirror.  If your mirror is not in the United States or you are
    otherwise seeing suboptimal speed from this source we recommend performing the **initial** sync from a mirror
@@ -37,7 +37,7 @@ Use updated version of `rsync` with `xxhash` support.
 3. Create a cron task to sync it periodically (we recommend updating the
    mirror every 3 hours):
    ```shell
-   0 */3 * * * sleep $(((RANDOM\%3500)+1)) && /usr/bin/flock -n /var/run/almalinux_rsync.lock -c "/usr/bin/rsync -avSH -f 'R .~tmp~' --delete-delay --delay-updates rsync://rsync.repo.almalinux.org/almalinux/ /almalinux/dir/on/your/server/"
+   0 */3 * * * sleep $(((RANDOM\%3500)+1)) && /usr/bin/flock -n /var/run/almalinux_rsync.lock -c "/usr/bin/rsync -avSH --exclude='.~tmp~' --delete-delay --delay-updates rsync://rsync.repo.almalinux.org/almalinux/ /almalinux/dir/on/your/server/"
    ```
 4. Ensure the accuracy of city, longitude, and latitude data for your mirror IP(s) with IPinfo at
    [https://ipinfo.io](https://ipinfo.io).

--- a/docs/Mirrors.md
+++ b/docs/Mirrors.md
@@ -27,7 +27,7 @@ Use updated version of `rsync` with `xxhash` support.
      xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
      ```
 :::
-2. Synchronize with the official AlmaLinux mirror via `rsync`:  
+2. Synchronize with the official AlmaLinux mirror via `rsync`:
    ```shell
    /usr/bin/rsync -avSH --exclude='.~tmp~' --delete-delay --delay-updates rsync://rsync.repo.almalinux.org/almalinux/ /almalinux/dir/on/your/server/
    ```
@@ -60,7 +60,7 @@ Use updated version of `rsync` with `xxhash` support.
    You can use the [official AlmaLinux repo file](https://github.com/AlmaLinux/mirrors/blob/master/mirrors.d/repo.almalinux.org.yml)
    as an example. Your mirror does not have to provide all the protocols
    that our main mirror provides, but either HTTP or HTTPS is required. Format of a mirror's config is described below.
-   Also, you can validate your config to use some JSON online validator using [that JSON schema](https://github.com/AlmaLinux/mirrors/blob/yaml_snippets/json_schemas/mirror_config.json) and converting your config to JSON.  
+   Also, you can validate your config to use some JSON online validator using [that JSON schema](https://github.com/AlmaLinux/mirrors/blob/yaml_snippets/json_schemas/mirror_config.json) and converting your config to JSON.
 
     ```YAML
     ---


### PR DESCRIPTION
Hi,
I discussed that in an email with @codyro and @jonathanspw. Can someone please verify my interpretation here?

R means risk, i.e. "receiver-only include" according to the manual. I believe it was a mistake because these temporary files 
should be excluded, not included.

I've added a second commit to remove unnecessary trailing whitespace.