### PR TITLE
Migration.md - SIG staff update

### DIFF
--- a/docs/sigs/Migration.md
+++ b/docs/sigs/Migration.md
@@ -53,6 +53,3 @@ If you can help, please join us at [Migration SIG on Mattermost](https://chat.al
 * [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - The AlmaLinux OS Architect.
   * Chat login: [alukoshko](https://chat.almalinux.org/almalinux/messages/@alukoshko)
   * GitHub profile: [andrewlukoshko](https://github.com/andrewlukoshko)
-* [Kamil Aronowski](mailto:ka@euro-linux.com) - [EuroLinux](https://euro-linux.com) DevOps Engineer
-  * Chat login: [aronowski](https://chat.almalinux.org/almalinux/messages/@aronowski)
-  * GitHub profile: [aronowski](https://github.com/aronowski)


### PR DESCRIPTION
Since I haven't been involved in the migration SIG for a long time and I'm not keeping track of what's happening in the Enterprise Linux migration environment, it's safe to remove a mention of me from the SIG team as described in `Migration.md`.

Also, I no longer use that formal job title I've been using back then - no need to be presented with outdated information.