### PR TITLE
Add supported architectures and beta dates

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -12,10 +12,10 @@ Version 9 will have active support until 31 May 2027, and security support until
 
 | Release | Codename | Beta Date | Release Date | Kernel | Supported Architectures |
 |---|---|---|---|---|---|
-| [9.3](/release-notes/9.3)| Shamrock Pampas Cat | 26 Oct 2023 | 13 November 2023 | 5.14.0-362.8.1 | x86_64, aarch64, ppc64le, s390x |
-| [9.2](/release-notes/9.2) | Turquoise Kodkod | 27 April 2023 | 10 May 2023 | 5.14.0-284.11.1 | x86_64, aarch64, ppc64le, s390x |
-| [9.1](/release-notes/9.1) | Lime Lynx | 02 November 2022 | 16 November 2022 | 5.14.0-162.6.1 | x86_64, aarch64, ppc64le, s390x |
-| [9.0](/release-notes/9.0) | Emerald Puma | April 2022 | 26 May 2022 | 5.14.0-70.13.1 | x86_64, aarch64, ppc64le, s390x  |
+| [9.3](/release-notes/9.3)| Shamrock Pampas Cat | Oct 26 2023 | Nov 13 2023 | 5.14.0-362.8.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.2](/release-notes/9.2) | Turquoise Kodkod | Apr 27 2023 | May 10 2023 | 5.14.0-284.11.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.1](/release-notes/9.1) | Lime Lynx | Nov 2 2022 | Nov 16 2022 | 5.14.0-162.6.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.0](/release-notes/9.0) | Emerald Puma | Apr 19 2022 | May 26 2022 | 5.14.0-70.13.1 | x86_64, aarch64, ppc64le, s390x  |
 
 ### AlmaLinux 8
 
@@ -23,13 +23,13 @@ Version 8 will have active support until 01 May 2024, and security support until
 
 | Release | Codename | Beta Date | Release Date | Kernel | Supported Architectures |
 |---|---|---|---|---|---|
-| [8.9](/release-notes/8.9) | Midnight Oncilla | 2 Nov 2023 | 21 November 2023 | 4.18.0-513.5.1 | x86_64, aarch64, ppc64le, s390x |
-| [8.8](/release-notes/8.8) | Sapphire Caracal | 21 April 2023 | 18 May 2023 | 4.18.0-477.10.1 | x86_64, aarch64, ppc64le, s390x |
-| [8.7](/release-notes/8.7) | Stone Smilodon | 25 October 2022 | 10 November 2022 | 4.18.0-425.3.1 | x86_64, aarch64, ppc64le, s390x |
-| [8.6](/release-notes/8.6) | Sky Tiger | 06 May 2022 | 12 May 2022 | 4.18.0-372.9.1 | x86_64, aarch64, ppc64le, s390x |
-| [8.5](/release-notes/8.5) | Arctic Sphynx | 13 October 2021 | 12 November 2021 | 4.18.0-348 | x86_64, aarch64, ppc64le |
-| [8.4](/release-notes/8.4) | Electric Cheetah | 20 April 2021 | 26 May 2021 | 4.18.0-305 | x86_64, aarch64 |
-| [8.3](/release-notes/8.3) | Purple Manul | 1 Feb 2021 | 30 March 2021 | 4.18.0-240 | x86_64 |
+| [8.9](/release-notes/8.9) | Midnight Oncilla | Nov 2 2023 | Nov 21 2023 | 4.18.0-513.5.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.8](/release-notes/8.8) | Sapphire Caracal | Apr 21 2023 | May 18 2023 | 4.18.0-477.10.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.7](/release-notes/8.7) | Stone Smilodon | Oct 25 2022 | Nov 10 2022 | 4.18.0-425.3.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.6](/release-notes/8.6) | Sky Tiger | May 06 2022 | May 12 2022 | 4.18.0-372.9.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.5](/release-notes/8.5) | Arctic Sphynx | Oct 13 2021 | Nov 12 2021 | 4.18.0-348 | x86_64, aarch64, ppc64le |
+| [8.4](/release-notes/8.4) | Electric Cheetah | Apr 20 2021 | May 26 2021 | 4.18.0-305 | x86_64, aarch64 |
+| [8.3](/release-notes/8.3) | Purple Manul | Feb 1 2021 | Mar 30 2021 | 4.18.0-240 | x86_64 |
 
 **Run the following commands to find:**
 * your AlmaLinux release

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -8,28 +8,28 @@ These are AlmaLinux Release Notes listed with Release Version, General Availabil
 
 ### AlmaLinux 9
 
-Version 9 will have active support until 31 May 2027, and security support until 31 May 2032. 
+Version 9 will have active support until 31 May 2027, and security support until 31 May 2032. Release of new 9.x version ends support for the previous version.
 
-| Release | Codename | General Availability Date | Kernel |
-|---|---|---|---|
-| [9.3](/release-notes/9.3)| Shamrock Pampas Cat | 13 November 2023 | 5.14.0-362.8.1 | 
-| [9.2](/release-notes/9.2) | Turquoise Kodkod | 10 May 2023 | 5.14.0-284.11.1 |
-| [9.1](/release-notes/9.1) | Lime Lynx | 16 November 2022 | 5.14.0-162.6.1 |
-| [9.0](/release-notes/9.0) | Emerald Puma | 26 May 2022 | 5.14.0-70.13.1 |
+| Release | Codename | Beta Date | Release Date | Kernel | Supported Architectures |
+|---|---|---|---|---|---|
+| [9.3](/release-notes/9.3)| Shamrock Pampas Cat | 26 Oct 2023 | 13 November 2023 | 5.14.0-362.8.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.2](/release-notes/9.2) | Turquoise Kodkod | 27 April 2023 | 10 May 2023 | 5.14.0-284.11.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.1](/release-notes/9.1) | Lime Lynx | 02 November 2022 | 16 November 2022 | 5.14.0-162.6.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.0](/release-notes/9.0) | Emerald Puma | April 2022 | 26 May 2022 | 5.14.0-70.13.1 | x86_64, aarch64, ppc64le, s390x  |
 
 ### AlmaLinux 8
 
-Version 8 will have active support until 01 May 2024, and security support until 01 Mar 2029.
+Version 8 will have active support until 01 May 2024, and security support until 01 Mar 2029. Release of new 8.x version ends support for the previous version.
 
-| Release | Codename | General Availability Date | Kernel |
-|---|---|---|---|
-| [8.9](/release-notes/8.9) | Midnight Oncilla | 21 November 2023 | 4.18.0-513.5.1 |
-| [8.8](/release-notes/8.8) | Sapphire Caracal | 18 May 2023 | 4.18.0-477.10.1 |
-| [8.7](/release-notes/8.7) | Stone Smilodon | 10 November 2022 | 4.18.0-425.3.1 |
-| [8.6](/release-notes/8.6) | Sky Tiger | 12 May 2022|4.18.0-372.9.1 |
-| [8.5](/release-notes/8.5) | Arctic Sphynx | 12 November 2021|4.18.0-348 |
-| [8.4](/release-notes/8.4) | Electric Cheetah | 26 May 2021 | 4.18.0-305 |
-| [8.3](/release-notes/8.3) | Purple Manul | 30 March 2021 | 4.18.0-240 |
+| Release | Codename | Beta Date | Release Date | Kernel | Supported Architectures |
+|---|---|---|---|---|---|
+| [8.9](/release-notes/8.9) | Midnight Oncilla | 2 Nov 2023 | 21 November 2023 | 4.18.0-513.5.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.8](/release-notes/8.8) | Sapphire Caracal | 21 April 2023 | 18 May 2023 | 4.18.0-477.10.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.7](/release-notes/8.7) | Stone Smilodon | 25 October 2022 | 10 November 2022 | 4.18.0-425.3.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.6](/release-notes/8.6) | Sky Tiger | 06 May 2022 | 12 May 2022 | 4.18.0-372.9.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.5](/release-notes/8.5) | Arctic Sphynx | 13 October 2021 | 12 November 2021 | 4.18.0-348 | x86_64, aarch64, ppc64le |
+| [8.4](/release-notes/8.4) | Electric Cheetah | 20 April 2021 | 26 May 2021 | 4.18.0-305 | x86_64, aarch64 |
+| [8.3](/release-notes/8.3) | Purple Manul | 1 Feb 2021 | 30 March 2021 | 4.18.0-240 | x86_64 |
 
 **Run the following commands to find:**
 * your AlmaLinux release

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -12,10 +12,10 @@ Version 9 will have active support until 31 May 2027, and security support until
 
 | Release | Codename | Beta Date | Release Date | Kernel | Supported Architectures |
 |---|---|---|---|---|---|
-| [9.3](/release-notes/9.3)| Shamrock Pampas Cat | Oct 26 2023 | Nov 13 2023 | 5.14.0-362.8.1 | x86_64, aarch64, ppc64le, s390x |
-| [9.2](/release-notes/9.2) | Turquoise Kodkod | Apr 27 2023 | May 10 2023 | 5.14.0-284.11.1 | x86_64, aarch64, ppc64le, s390x |
-| [9.1](/release-notes/9.1) | Lime Lynx | Nov 2 2022 | Nov 16 2022 | 5.14.0-162.6.1 | x86_64, aarch64, ppc64le, s390x |
-| [9.0](/release-notes/9.0) | Emerald Puma | Apr 19 2022 | May 26 2022 | 5.14.0-70.13.1 | x86_64, aarch64, ppc64le, s390x  |
+| [9.3](/release-notes/9.3)| Shamrock Pampas Cat | 26 Oct 2023 | 13 November 2023 | 5.14.0-362.8.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.2](/release-notes/9.2) | Turquoise Kodkod | 27 April 2023 | 10 May 2023 | 5.14.0-284.11.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.1](/release-notes/9.1) | Lime Lynx | 02 November 2022 | 16 November 2022 | 5.14.0-162.6.1 | x86_64, aarch64, ppc64le, s390x |
+| [9.0](/release-notes/9.0) | Emerald Puma | April 2022 | 26 May 2022 | 5.14.0-70.13.1 | x86_64, aarch64, ppc64le, s390x  |
 
 ### AlmaLinux 8
 
@@ -23,13 +23,13 @@ Version 8 will have active support until 01 May 2024, and security support until
 
 | Release | Codename | Beta Date | Release Date | Kernel | Supported Architectures |
 |---|---|---|---|---|---|
-| [8.9](/release-notes/8.9) | Midnight Oncilla | Nov 2 2023 | Nov 21 2023 | 4.18.0-513.5.1 | x86_64, aarch64, ppc64le, s390x |
-| [8.8](/release-notes/8.8) | Sapphire Caracal | Apr 21 2023 | May 18 2023 | 4.18.0-477.10.1 | x86_64, aarch64, ppc64le, s390x |
-| [8.7](/release-notes/8.7) | Stone Smilodon | Oct 25 2022 | Nov 10 2022 | 4.18.0-425.3.1 | x86_64, aarch64, ppc64le, s390x |
-| [8.6](/release-notes/8.6) | Sky Tiger | May 06 2022 | May 12 2022 | 4.18.0-372.9.1 | x86_64, aarch64, ppc64le, s390x |
-| [8.5](/release-notes/8.5) | Arctic Sphynx | Oct 13 2021 | Nov 12 2021 | 4.18.0-348 | x86_64, aarch64, ppc64le |
-| [8.4](/release-notes/8.4) | Electric Cheetah | Apr 20 2021 | May 26 2021 | 4.18.0-305 | x86_64, aarch64 |
-| [8.3](/release-notes/8.3) | Purple Manul | Feb 1 2021 | Mar 30 2021 | 4.18.0-240 | x86_64 |
+| [8.9](/release-notes/8.9) | Midnight Oncilla | 2 Nov 2023 | 21 November 2023 | 4.18.0-513.5.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.8](/release-notes/8.8) | Sapphire Caracal | 21 April 2023 | 18 May 2023 | 4.18.0-477.10.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.7](/release-notes/8.7) | Stone Smilodon | 25 October 2022 | 10 November 2022 | 4.18.0-425.3.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.6](/release-notes/8.6) | Sky Tiger | 06 May 2022 | 12 May 2022 | 4.18.0-372.9.1 | x86_64, aarch64, ppc64le, s390x |
+| [8.5](/release-notes/8.5) | Arctic Sphynx | 13 October 2021 | 12 November 2021 | 4.18.0-348 | x86_64, aarch64, ppc64le |
+| [8.4](/release-notes/8.4) | Electric Cheetah | 20 April 2021 | 26 May 2021 | 4.18.0-305 | x86_64, aarch64 |
+| [8.3](/release-notes/8.3) | Purple Manul | 1 Feb 2021 | 30 March 2021 | 4.18.0-240 | x86_64 |
 
 **Run the following commands to find:**
 * your AlmaLinux release


### PR DESCRIPTION
I am often trying to find historical information about when we added builds or when betas were released for specific versions, and I assume I'm not the only one. I'd like to add this information to this table on the release notes page to make it easy to find. 

In my second commit I also changed the date format to something more readable. I'm not married to the idea that it has to change, but if no one objects I would love it. 