### PR TITLE
adding the javascript to allow web stats gathering.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,7 +2,19 @@
 module.exports = {
   title: 'AlmaLinux Wiki',
   description: 'AlmaLinux OS Documentation',
-  head: [
+  head: [ ['script', {}, `
+	  var _paq = window._paq = window._paq || [];
+	  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+	  _paq.push(['trackPageView']);
+	  _paq.push(['enableLinkTracking']);
+	  (function() {
+	    var u="https://matomo.almalinux.org/";
+	    _paq.push(['setTrackerUrl', u+'matomo.php']);
+	    _paq.push(['setSiteId', '5']);
+	    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+	    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+	  })();
+`],
     ['link', { rel: "shortcut icon", type: 'image/png', href: "/images/logo.png"}],
   ],
   base: '/',


### PR DESCRIPTION
Added the javascript for matomo using the code from the dashboard and the directions in [this issue](https://github.com/vuejs/vuepress/issues/790).  When deploying locally, it seems to do so without any errors, and it looks like it's including the code in the source, so I think it should be okay!

![2024-03-27_16-07-10](https://github.com/AlmaLinux/wiki/assets/13630986/9517c49b-595e-4de1-853c-15a14a51de26)
