### PR TITLE
Adding Help-translating-site

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -37,6 +37,7 @@ module.exports = {
             '/Contribute',
             '/Contribute-to-Documentation',
             '/Mirrors',
+            '/Help-translating-site',
             {
               title: 'Special interest groups (SIGs)',
               path: '/sigs/',

--- a/docs/sigs/Marketing.md
+++ b/docs/sigs/Marketing.md
@@ -42,7 +42,7 @@ Contributions take all kinds of shapes and sizes, and we welcome everyone! If yo
 * Content writers -- especially for the blog and social media
 * Website maintainers -- our Hugo migration is complete, but we need to clean it up
 * Graphic designers -- we have sticker ideas, but they aren't nearly as pretty as they could be!
-* Website translations -- accepted through [Weblate](https://hosted.weblate.org/projects/almalinux/website-backend/), automatically sent to the website repo for merging in. 
+* Website translations -- accepted through [Weblate](https://hosted.weblate.org/projects/almalinux/website-backend/), automatically sent to the website repo for merging in. To contribute, take a look at the ["Help translating site"](/Help-translating-site.html) guide.
 
 We have tons of ideas and bugs on the [website repo](https://github.com/AlmaLinux/almalinux.org) and on [GitHub Projects](https://github.com/orgs/AlmaLinux/projects/5/views/1).
 


### PR DESCRIPTION
The new Help-translating-site didn't get added to the menu (my fault for missing it).Adding the new doc to the menu, and adding a link to the marketing SIG doc