### PR TITLE
Remove leading spaces on backticks to fix code formatting on ELevate CentOS 6 to CentOS 7 guide

### DIFF
--- a/docs/elevate/ELevating-CentOS6-to-CentOS7.md
+++ b/docs/elevate/ELevating-CentOS6-to-CentOS7.md
@@ -26,9 +26,9 @@ The process consists of two steps:
 Please, check the **Details** below for guidance on how to enable the CentOS Vault repositories.
   :::details
   To migrate your CentOS 6 machine, you need working CentOS 6 repositories. Run the below command replace your CentOS-base repo file with a known-good CentOS 6.10 Vault repository configuration:
-    ```sh
+```sh
     curl https://repo.almalinux.org/elevate/el6/centos6-vault.repo -o /etc/yum.repos.d/CentOS-Base.repo
-    ```
+```
    :::
 
 ## Upgrade CentOS 6.10 to CentOS 7.2.1511


### PR DESCRIPTION
The snippet's formatting in the collapsable `DETAILS` section under `Requirements` was incorrect, leading to an invalid command being displayed. This PR removes the leading spaces in the backticks, fixing the formatting.

https://wiki.almalinux.org/elevate/ELevating-CentOS6-to-CentOS7.html#requirements

<img width="1284" alt="image" src="https://github.com/AlmaLinux/wiki/assets/196810/3882559c-8e8c-468c-a603-d85c19c7a3fd">
