### PR TITLE
Rename Building Packages for AlmaLinux to AlmaLinux Package Building Guide

### DIFF
--- a/docs/documentation/building-packages-guide.md
+++ b/docs/documentation/building-packages-guide.md
@@ -1,8 +1,8 @@
 ---
-title: Building Packages Guide
+title: AlmaLinux Package Building Guide
 ---
 
-# Building packages for AlmaLinux
+# AlmaLinux Package Building Guide
 
 This guide contains step-by-step instructions on how to build for AlmaLinux packages for different architectures. It also includes some background information about the mock tool, setup instructions, and some examples. These details can be helpful for the building packages for the AlmaLinux project.
 


### PR DESCRIPTION
Renamed "Building Packages for AlmaLinux" to "AlmaLinux Package Building Guide", https://github.com/AlmaLinux/wiki/issues/253.