### PR TITLE
Updated "A05 ❯ Multimedia Codecs Installation Guide"

### DIFF
--- a/docs/series/system/SystemSeriesA05.md
+++ b/docs/series/system/SystemSeriesA05.md
@@ -3,27 +3,24 @@
 <hr>
 | 💡 | Experience Level  | ⭐☆☆☆☆ |
 |--- | --------- | --------|
-| 📆 | <small>Last modified </small>| 2023-06-22
+| 📆 | <small>Last modified </small>| 2024-06-11
 | 🔧 | <small>Tested by <br> ↳ version \| platform \| date </small>| NOT TESTED YET |
 
 
-# Enable CRB:
-```Bash
-sudo dnf config-manager --set-enabled crb
-```
-# Add EPEL9:
+# Add EPEL:
 
 ```Bash
 sudo dnf -y install epel-release
 sudo dnf makecache
 ```
 
-# Add RPMFusion:
+# Enable CRB:
 ```Bash
-sudo dnf -y install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm
-sudo dnf -y install rpmfusion-free-release-tainted rpmfusion-nonfree-release-tainted
-sudo dnf makecache
+sudo dnf config-manager --set-enabled crb
 ```
+
+# Add RPMFusion:
+Starting from step 2, follow [Installing EPEL and RPM Fusion](/documentation/epel-and-rpmfusion/).
 
 # Install multimedia codecs:
 


### PR DESCRIPTION
## What does this pull request do?

This pull switches two of the instructions in the Codecs instillation guide, and replaces instructions in a third one (Installing EPEL) with a hyperlink.

## Why?

The first two instructions on the Codecs Installation Guide are in the opposite order of how they appear in the "Extra Repositories" (https://wiki.almalinux.org/repos/Extras.html) page, so they were flipped around to match said page.

In addition, the current guide for installing RPMfusion (which provides additional packages) on the Codecs Installation Guide was different from the one on "Installing EPEL and RPM Fusion" , so it was replaced with the URL to
https://wiki.almalinux.org/documentation/epel-and-rpmfusion.html instead. This should also help de-duplicate information on the wiki just in case one page gets updated without the other in the future.