### PR TITLE
Formatted the headings of " A05 ❯ Multimedia Codecs Installation Guide"

### DIFF
--- a/docs/series/system/SystemSeriesA05.md
+++ b/docs/series/system/SystemSeriesA05.md
@@ -7,39 +7,39 @@
 | 🔧 | <small>Tested by <br> ↳ version \| platform \| date </small>| NOT TESTED YET |
 
 
-# Add EPEL:
+## Add EPEL:
 
 ```Bash
 sudo dnf -y install epel-release
 sudo dnf makecache
 ```
 
-# Enable CRB:
+## Enable CRB:
 ```Bash
 sudo dnf config-manager --set-enabled crb
 ```
 
-# Add RPMFusion:
+## Add RPMFusion:
 Starting from step 2, follow [Installing EPEL and RPM Fusion](/documentation/epel-and-rpmfusion/).
 
-# Install multimedia codecs:
+## Install multimedia codecs:
 
 ```bash
 sudo dnf -y group install multimedia
 sudo dnf -y install ffmpeg ffmpeg-libs ffmpeg-devel mpv
 ```
 
-# Extra Audio packages
+## Extra Audio packages
 ```bash
 sudo dnf -y group install sound-and-video
 ```
 
-# Play a DVD
+## Play a DVD
 ```Bash
 sudo dnf -y install libdvdcss
 ```
 
-# Install mediaplayers like VLC, MPV or Celluloid from RPMFusion
+## Install mediaplayers like VLC, MPV or Celluloid from RPMFusion
 ```bash
 sudo dnf install vlc
 sudo dnf install mpv


### PR DESCRIPTION
## What does this pull request do?

This turns all but the first H1 on the page of https://wiki.almalinux.org/series/system/SystemSeriesA05.html into H2s.

## Why?

Having more than one H1 per page messes with the structure of the page. This is also the only System Series article that is structured like this.