### PR TITLE
Epel and rpmfusion guide

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -139,10 +139,6 @@ module.exports = {
         title: 'Documentation',
         children: [
             '/Comparison',
-            {
-                title: 'Installing EPEL and RPM Fusion',
-                path: '/documentation/epel-and-rpmfusion',
-            },
             '/FAQ',
             '/Howto',
             {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -139,6 +139,10 @@ module.exports = {
         title: 'Documentation',
         children: [
             '/Comparison',
+            {
+                title: 'Installing EPEL and RPM Fusion',
+                path: '/documentation/epel-and-rpmfusion',
+            },
             '/FAQ',
             '/Howto',
             {

--- a/docs/Howto.md
+++ b/docs/Howto.md
@@ -4,7 +4,7 @@ title: 'Howtos'
 # AlmaLinux Howto Guides (external)
 
 ## Installation Guides
-- [EPEL and RPM Fusion](/docs/documentation/epel-and-rpmfusion.md)
+- [EPEL and RPM Fusion](/documentation/epel-and-rpmfusion)
 - [ionCube Loader](https://cloud7.news/how-tos/how-to-install-ioncube-loader-in-almalinux/) 
 - [Varnish](https://cloud7.news/how-tos/how-to-install-varnish-on-almalinux/) 
 - [Nginx](https://orcacore.com/install-nginx-web-server-almalinux-9/)

--- a/docs/documentation/epel-and-rpmfusion.md
+++ b/docs/documentation/epel-and-rpmfusion.md
@@ -7,12 +7,12 @@ title: "Installing EPEL and RPM Fusion"
 This guide describes how to install _Extra Packages for Enterprise Linux (EPEL)_ and _RPM Fusion_, two software repositories that contain software that is not included by AlmaLinux (like codecs).
 
 :::warning
-These third-party software repositories may not be supported by AlmaLinux's [ELevate Project](../elevate/).
+These third-party software repositories may not be supported by AlmaLinux's [ELevate Project](/elevate/).
 :::
 
 ## Step 1: Install EPEL. 
 Installing EPEL is required for RPM Fusion.
-1. Follow the instructions [described here](../repos/Extras.md) to install EPEL.
+1. Follow the instructions [described here](/repos/Extras) to install EPEL.
 
 	
 ## Step 2: Install (and verify) the RPM Fusion GPG keys

--- a/docs/repos/Extras.md
+++ b/docs/repos/Extras.md
@@ -46,4 +46,4 @@ dnf config-manager --set-enabled crb
 
 | Repository | How to Enable |
 | --- | --- |
-| ELRepo | See _[Installing EPEL and RPM Fusion](../documentation/epel-and-rpmfusion.md)_ |
+| ELRepo | See _[Installing EPEL and RPM Fusion](/documentation/epel-and-rpmfusion)_ |


### PR DESCRIPTION
I currently have 404 when accessing the guide from Howtos. Also updated other cross-links to pages. 