### PR TITLE
Not enough space in overlay file on XFS filesystem

### DIFF
--- a/docs/elevate/ELevate-frequent-issues.md
+++ b/docs/elevate/ELevate-frequent-issues.md
@@ -43,8 +43,15 @@ dracut -f --regenerate-all
 
 ## Leapp upgrade error "More space needed on the / filesystem"
 
-If the `leapp upgrade` step fails with the "More space needed on the / filesystem" error, it is necessary to expand the `/var` partition. 
-For this purpose, we kindly ask you to search for a [suitable guide](https://docs.icdc.io/en/compute/faq/extenddisk/).
+If the `leapp upgrade` step fails with the "More space needed on the / filesystem" error, ther could be two separate problems:
+ 1. Not enough free space, it is necessary to expand the `/var` partition:
+    * For this purpose, we kindly ask you to search for a [suitable guide](https://docs.icdc.io/en/compute/faq/extenddisk/).
+ 2. For partition that uses XFS, instruct `leapp` to use bigger overlay file by setting environment variable before running `leapp` command (default is 2048 MB):
+```
+export LEAPP_OVL_SIZE=4096
+sudo leapp preupgrade
+sudo leapp preupgrade
+```
 
 ## sssd fails after migration
 

--- a/docs/elevate/ELevate-frequent-issues.md
+++ b/docs/elevate/ELevate-frequent-issues.md
@@ -43,15 +43,10 @@ dracut -f --regenerate-all
 
 ## Leapp upgrade error "More space needed on the / filesystem"
 
-If the `leapp upgrade` step fails with the "More space needed on the / filesystem" error, ther could be two separate problems:
- 1. Not enough free space, it is necessary to expand the `/var` partition:
+If the `leapp upgrade` step fails with the "More space needed on the / filesystem" error, there could be two separate problems:
+ 1. Not enough free space on the /var partition. In that case, it is necessary to expand the `/var` partition:
     * For this purpose, we kindly ask you to search for a [suitable guide](https://docs.icdc.io/en/compute/faq/extenddisk/).
- 2. For partition that uses XFS, instruct `leapp` to use bigger overlay file by setting environment variable before running `leapp` command (default is 2048 MB):
-```
-export LEAPP_OVL_SIZE=4096
-sudo leapp preupgrade
-sudo leapp preupgrade
-```
+ 2. For a partition that uses XFS, instruct `leapp` to use a bigger overlay file by setting the environment variable before running `leapp` command (default is 2048 MB):
 
 ## sssd fails after migration
 


### PR DESCRIPTION
On XFS, not enough space on / filesystem means that leapp needs bigger overlay file.
See [forum](https://forums.almalinux.org/t/at-least-48mb-more-space-needed-on-the-filesystem-running-leapp-upgrade/3808) and [documentation](https://leapp.readthedocs.io/en/latest/el7toel8/envars.html).