### PR TITLE
Adjust phrasing and Add almalinux el7 repo

### DIFF
--- a/docs/elevate/ELevate-NG-testing-guide.md
+++ b/docs/elevate/ELevate-NG-testing-guide.md
@@ -79,9 +79,9 @@ Currently, the following upgrade paths are available:
    ```
 
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
-   See how the update process goes in the console.
+   See how the upgrade process goes in the console.
 
-* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or upgrading them manually.
   ```
   cat /etc/redhat-release
   cat /etc/os-release
@@ -121,7 +121,7 @@ When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to
     leapp-data-almalinux-0.2-6.el7.noarch
     leapp-0.16.0-2.el7.noarch
    ```
-   As mentioned above, consider removing these packages or upgrading them manually to proceed with the update to AlmaLinux 9.
+   As mentioned above, consider removing these packages or upgrading them manually to proceed with the upgrade to AlmaLinux 9.
   
    :::tip
    If you face difficulties while removing the packages, the following command might help you:
@@ -209,9 +209,9 @@ After these preparations are completed, you can upgrade your AlmaLinux 8 machine
    :::
    
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
-   See how the update process goes in the console.
+   See how the upgrade process goes in the console.
 
-* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or upgrade them manually.
   ```
   cat /etc/redhat-release
   cat /etc/os-release

--- a/docs/elevate/ELevate-NG-testing-guide.md
+++ b/docs/elevate/ELevate-NG-testing-guide.md
@@ -29,8 +29,10 @@ Currently, the following upgrade paths are available:
 ## Upgrade CentOS 7 to AlmaLinux 8
 
 * Update the system to get the latest updates and reboot your machine.
-   ```
-   sudo yum update -y
+   **NOTE:** Since the CentOS 7 repositories are now offline you will need to swap to the CentOS vault, or you can use our CentOS 7 mirror that we've setup for use with ELevate:
+   ```bash
+   curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
+   yum upgrade -y
    sudo reboot
    ```
 

--- a/docs/elevate/ELevate-NG-testing-guide.md
+++ b/docs/elevate/ELevate-NG-testing-guide.md
@@ -7,26 +7,26 @@ title: "ELevate NG Testing Guide"
 # ELevate NG Testing Guide (Leapp version 0.19.0) 
 
 ::: warning
-Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that migration worked as expected before you attempt to migrate any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
+Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that upgrade worked as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
 :::
 
 The ELevate NG supports a number of 3rd party repositories:
-* EPEL support is currently available for the migrations to AlmaLinux OS only.
-* Imunify - for migrations to EL 8
-* KernelCare - for migrations to EL 8
+* EPEL support is currently available for upgrades to AlmaLinux OS only.
 * MariaDB - for all supported operating systems 
 * nginx - for all supported operating systems 
 * PostgreSQL - for all supported operating systems 
+* Imunify - for upgrades to EL 8
+* KernelCare - for upgrades to EL 8
 
-Currently, the following migration directions are available:
+Currently, the following upgrade paths are available:
 
 ![image](/images/ELevateNG.svg)
 
-\* - migration from Scientific Linux 7 to AlmaLinux 8 requires a workaround. Please, see more in the [known issues](#known-issues). <br>
-\** - migration to Oracle Linux 9 is available with the [Oracle Leapp utility](https://blogs.oracle.com/linux/post/upgrade-oracle-linux-8-to-oracle-linux-9-using-leapp) and will not be supported by ELevate project.
+\* - upgrading from Scientific Linux 7 to AlmaLinux 8 requires a workaround. Please, see more in the [known issues](#known-issues). <br>
+\** - upgrading to Oracle Linux 9 is available with the [Oracle Leapp utility](https://blogs.oracle.com/linux/post/upgrade-oracle-linux-8-to-oracle-linux-9-using-leapp) and will not be supported by ELevate project.
 
 
-## Migrate CentOS 7 to AlmaLinux 8
+## Upgrade CentOS 7 to AlmaLinux 8
 
 * Update the system to get the latest updates and reboot your machine.
    ```
@@ -40,7 +40,7 @@ Currently, the following migration directions are available:
    sudo rpm --import https://repo.almalinux.org/elevate/RPM-GPG-KEY-ELevate
    ```
 
-* Install leapp packages and migration data for AlmaLinux:  
+* Install leapp packages and upgrade data for AlmaLinux:  
    ```
    sudo yum install -y leapp-upgrade leapp-data-almalinux
    ```
@@ -48,7 +48,7 @@ Currently, the following migration directions are available:
 * Start a preupgrade check. In the meanwhile, the Leapp utility creates a special */var/log/leapp/leapp-report.txt* file that contains possible problems and recommended solutions. No rpm packages will be installed at this phase.
 
    :::warning
-   Preupgrade check will fail as the default install doesn't meet all requirements for migration.
+   Preupgrade check will fail as the default install doesn't meet all requirements for the upgrade.
    :::
 
    ```
@@ -79,7 +79,7 @@ Currently, the following migration directions are available:
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
    See how the update process goes in the console.
 
-* After reboot, login to the system and check how the migration went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
   ```
   cat /etc/redhat-release
   cat /etc/os-release
@@ -88,9 +88,9 @@ Currently, the following migration directions are available:
   sudo cat /var/log/leapp/leapp-upgrade.log
   ```
 
-## Prepare the system for migration to AlmaLinux 9
+## Prepare the system for upgrade to AlmaLinux 9
 
-When successfully migrated to AlmaLinux 8 OS, consider performing these steps to prepare your system for migration to AlmaLinux 9:
+When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to prepare your system for upgrading to AlmaLinux 9:
 
 * Navigate to the **/etc/** directory and use an editor of your choice to edit the **yum.conf** file. You need to remove everything from the **exclude** line especially that refers to elevate or leapp. 
    
@@ -119,7 +119,7 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
     leapp-data-almalinux-0.2-6.el7.noarch
     leapp-0.16.0-2.el7.noarch
    ```
-   As mentioned above, consider removing these packages or upgrading them manually to proceed with migration to AlmaLinux 9.
+   As mentioned above, consider removing these packages or upgrading them manually to proceed with the update to AlmaLinux 9.
   
    :::tip
    If you face difficulties while removing the packages, the following command might help you:
@@ -128,7 +128,7 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
    ``` 
    :::
    
-* You can also check for the packages left from the migration process and remove them: 
+* You can also check for the packages left from the upgrade process and remove them: 
    ```   
    rpm -qa | grep elevate
    rpm -qa | grep leapp
@@ -151,16 +151,16 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
    ```
    sudo rpm -e [keyname]
    ```   
-After these preparations are completed, you can migrate your AlmaLinux 8 machine to AlmaLinux 9. 
+After these preparations are completed, you can upgrade your AlmaLinux 8 machine to AlmaLinux 9. 
 
-## Migrating AlmaLinux 8 to AlmaLinux 9
+## Upgrading AlmaLinux 8 to AlmaLinux 9
 
 * Install ELevate version 0.19.0 repo config for AlmaLinux8:
    ```
    sudo curl -o /etc/yum.repos.d/elevate-ng.repo https://repo.almalinux.org/elevate/testing/elevate-ng-el$(rpm -E %rhel).repo
    ```
 
-* Install leapp packages and migration data for AlmaLinux:  
+* Install leapp packages and upgrade data for AlmaLinux:  
    ```
    sudo yum install -y leapp-upgrade leapp-data-almalinux
    ```
@@ -168,7 +168,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
 * Start a preupgrade check. In the meanwhile, the Leapp utility creates a special */var/log/leapp/leapp-report.txt* file that contains possible problems and recommended solutions. No rpm packages will be installed at this phase.
 
    :::warning
-   Preupgrade check will fail as the default install doesn't meet all requirements for migration.
+   Preupgrade check will fail as the default install doesn't meet all requirements for the upgrade.
    :::
 
    ```
@@ -187,7 +187,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
    sudo leapp answer --section check_vdo.confirm=True
    ```
    
-  You might also find the following issue in the **leapp-report** file that can interfere with the migration. Consider removing the file:
+  You might also find the following issue in the **leapp-report** file that can interfere with the upgrade. Consider removing the file:
    ```bash   
     Network configuration for unsupported device types detected
     Summary: RHEL 9 does not support the legacy network-scripts package that was deprecated in RHEL 8 in favor of NetworkManager. Files for device types that are not supported by NetworkManager are present in the system. Files with the problematic configuration:
@@ -209,7 +209,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
    See how the update process goes in the console.
 
-* After reboot, login to the system and check how the migration went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
   ```
   cat /etc/redhat-release
   cat /etc/os-release
@@ -220,15 +220,15 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
   
 ## Demo Video
 
-Check Demo of a CentOS 7.x to AlmaLinux 8.x migration using the software and data provided by the AlmaLinux ELevate Project. 
+Here we have provided a demo of a CentOS 7.x to AlmaLinux 8.x upgrade using the AlmaLinux ELevate Project. 
 
 <iframe width="856" height="482" src="https://www.youtube.com/embed/Vzl9QxG5mvo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Known Issues
 
-### Migrating from Scientific Linux 7
+### Upgrading from Scientific Linux 7
 
-Migration from Scientific Linux 7 to AlmaLinux 8 requires a workaround. You can apply it by running the following command before the preupgrade check: 
+Upgrading from Scientific Linux 7 to AlmaLinux 8 requires a workaround. You can apply it by running the following command before the preupgrade check: 
 
   ```
   rm -rf /usr/share/redhat-release /usr/share/doc/redhat-release

--- a/docs/elevate/ELevate-NG-testing-guide.md
+++ b/docs/elevate/ELevate-NG-testing-guide.md
@@ -31,8 +31,8 @@ Currently, the following upgrade paths are available:
 * Update the system to get the latest updates and reboot your machine.
    **NOTE:** Since the CentOS 7 repositories are now offline you will need to swap to the CentOS vault, or you can use our CentOS 7 mirror that we've setup for use with ELevate:
    ```bash
-   curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
-   yum upgrade -y
+   sudo curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
+   sudo yum upgrade -y
    sudo reboot
    ```
 

--- a/docs/elevate/ELevate-NG-testing-guide.md
+++ b/docs/elevate/ELevate-NG-testing-guide.md
@@ -7,7 +7,7 @@ title: "ELevate NG Testing Guide"
 # ELevate NG Testing Guide (Leapp version 0.19.0) 
 
 ::: warning
-Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that upgrade worked as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
+Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify the upgrade worked as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
 :::
 
 The ELevate NG supports a number of 3rd party repositories:

--- a/docs/elevate/ELevate-frequent-issues.md
+++ b/docs/elevate/ELevate-frequent-issues.md
@@ -2,7 +2,7 @@
 title: ELevate Frequent Issues
 ---
 
-###### last updated: 2023-03-27
+###### last updated: 2024-07-08
 
 # ELevate Frequent Issues
 
@@ -10,7 +10,7 @@ These are the ELevate project issues the AlmaLinux team and community are curren
 
 ## Leapp upgrade error caused by important modules from kernel drivers
 
-Proceeding with migration, you can get the "Detected loaded kernel drivers, which have been removed" error. 
+Proceeding with the upgrade, you can get the "Detected loaded kernel drivers, which have been removed" error. 
 
 The issue can be caused by the mentioned modules: 
 * mptbase
@@ -46,9 +46,9 @@ dracut -f --regenerate-all
 If the `leapp upgrade` step fails with the "More space needed on the / filesystem" error, it is necessary to expand the `/var` partition. 
 For this purpose, we kindly ask you to search for a [suitable guide](https://docs.icdc.io/en/compute/faq/extenddisk/).
 
-## sssd fails after migration
+## sssd fails after upgrade
 
-After migration, there may be problems with sssd.
+After upgrading, there may be problems with sssd.
 
 Follow these steps to resolve the issue:
 
@@ -66,10 +66,10 @@ systemctl restart sssd
 
 ## ELevate fails due to initramfs missing a module
 
-When upgrading a CentOS 7 machine to an EL8 derivative, after completing the `leapp upgrade` step the process can fail during reboot showing an initramfs error. This is possible due to the removed drivers support in EL8 that were supported in EL7. 
+When upgrading a CentOS 7 machine to an EL8 derivative, after completing the `leapp upgrade` step the process can fail during reboot showing an initramfs error. This is possible due to the lack of support for certain drives in EL8 that were supported in EL7. 
 
 :::warning
-These steps are helpful at migrating to AlmaLinux OS version **8.8** or a lower version if necessary. Once the migration is complete, you can upgrade your AlmaLinux system to the latest version **8.10** by running the following command:"
+These steps are helpful at upgrading to AlmaLinux OS version **8.8** or a lower version if necessary. Once the upgrade is complete, you can upgrade your AlmaLinux system to the latest version **8.10** by running the following command:"
   ```
   dnf update
   ```
@@ -78,7 +78,7 @@ These steps are helpful at migrating to AlmaLinux OS version **8.8** or a lower 
 To resolve this issue, please, follow the steps below: 
 * Find out what module is missing. 
 * Check if it's possible to use such a package from [elrepo.org](https://elrepo.org/wiki/doku.php?id=deviceids). In order not to get any dependency errors, we recommend looking for a package for EL version **8.8**. 
-* For the same reason, we recommend migrating your CentOS 7 machine to AlmaLinux OS version **8.8**. To do so, you need to navigate to the */etc/leapp/files/* directory and edit the **leapp_upgrade_repositories.repo** to lower the AlmaLinux version in `baseurl/mirror` to 8.8.
+* For the same reason, we recommend upgrading your CentOS 7 machine to AlmaLinux OS version **8.8**. To do so, you need to navigate to the */etc/leapp/files/* directory and edit the **leapp_upgrade_repositories.repo** to lower the AlmaLinux version in `baseurl/mirror` to 8.8.
 * If the package is present in ELRepo, modify the leapp code to add a needed driver to ELevate initramfs. 
     * Navigate to the */etc/leapp/files/* directory and add the ELRepo repository to the **leapp_upgrade_repositories.repo** file:
        ```

--- a/docs/elevate/ELevate-quickstart-guide.md
+++ b/docs/elevate/ELevate-quickstart-guide.md
@@ -40,8 +40,8 @@ Currently, the following upgrade paths are available:
    ```
    **NOTE:** Since the CentOS 7 repositories are now offline you will need to swap to the CentOS vault, or you can use our CentOS 7 mirror that we've setup for use with ELevate:
    ```bash
-   curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
-   yum upgrade -y
+   sudo curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
+   sudo yum upgrade -y
    sudo reboot
    ```
 

--- a/docs/elevate/ELevate-quickstart-guide.md
+++ b/docs/elevate/ELevate-quickstart-guide.md
@@ -38,6 +38,12 @@ Currently, the following upgrade paths are available:
    sudo yum update -y
    sudo reboot
    ```
+   **NOTE:** Since the CentOS 7 repositories are now offline you will need to swap to the CentOS vault, or you can use our CentOS 7 mirror that we've setup for use with ELevate:
+   ```bash
+   curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
+   yum upgrade -y
+   sudo reboot
+   ```
 
 * Install `elevate-release` package with the project repo and GPG key.
 ```

--- a/docs/elevate/ELevate-quickstart-guide.md
+++ b/docs/elevate/ELevate-quickstart-guide.md
@@ -7,7 +7,7 @@ title: "ELevate Quickstart Guide"
 # ELevate Quickstart Guide
 
 ::: warning
-Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that the upgrade worked as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
+Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify the upgrade worked as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
 :::
 
 This guide contains steps on how to upgrade your RHEL-based operating system to the next major version.

--- a/docs/elevate/ELevate-quickstart-guide.md
+++ b/docs/elevate/ELevate-quickstart-guide.md
@@ -2,18 +2,18 @@
 title: "ELevate Quickstart Guide"
 ---
 
-###### last updated: 2024-04-18
+###### last updated: 2024-07-08
 
 # ELevate Quickstart Guide
 
 ::: warning
-Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that migration worked as expected before you attempt to migrate any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
+Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that the upgrade worked as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
 :::
 
 This guide contains steps on how to upgrade your RHEL-based operating system to the next major version.
 
 :::tip 
-Please note that the ELevate project is designed to perform one-step migrations. If you wish to perform a two-steps migration from CentOS7, you need to split the process. Please check the [ELevating CentOS7 to AlmaLinux 9](/elevate/ELevating-CentOS7-to-AlmaLinux-9.md) guide for more information.
+Please note that the ELevate project is designed to perform one-step upgrades. If you wish to perform an upgrade from CentOS7, you need to split the process. Please check the [ELevating CentOS7 to AlmaLinux 9](/elevate/ELevating-CentOS7-to-AlmaLinux-9.md) guide for more information.
 :::
 
 The ELevate supports a number of 3rd party repositories for all supported systems:
@@ -24,28 +24,27 @@ The ELevate supports a number of 3rd party repositories for all supported system
 * nginx
 * PostgreSQL
 
-Currently, the following migration directions are available:
+Currently, the following upgrade paths are available:
 
 ![image](/images/ELevate.svg)
 
-\* - migration to CentOS Stream 9 is currently in process and will be available later. <br>
-\** - migration to Oracle Linux 9 is available with the [Oracle Leapp utility](https://blogs.oracle.com/linux/post/upgrade-oracle-linux-8-to-oracle-linux-9-using-leapp) and will not be supported by ELevate project.
+\* - upgrade to CentOS Stream 9 is currently in process and will be available later. <br>
+\** - upgrade to Oracle Linux 9 is available with the [Oracle Leapp utility](https://blogs.oracle.com/linux/post/upgrade-oracle-linux-8-to-oracle-linux-9-using-leapp) and will not be supported by ELevate project.
 
 **Requirements:** You need CentOS 7, AlmaLinux 8, EuroLinux 8 or Rocky Linux 8 system installed to use this guide.
 
-* Fully updated system is required to accomplish the upgrade. So, install the latest updates first, and reboot.
-```
-sudo yum update -y
-sudo reboot
-```
+* A fully updated system is required to accomplish the upgrade. So, install the latest updates first, and reboot.
+   ```
+   sudo yum update -y
+   sudo reboot
+   ```
 
 * Install `elevate-release` package with the project repo and GPG key.
 ```
 sudo yum install -y http://repo.almalinux.org/elevate/elevate-release-latest-el$(rpm --eval %rhel).noarch.rpm
 ```
 
-
-* Install leapp packages and migration data for the OS you want to upgrade. Possible options are:
+* Install leapp packages and upgrade data for the OS you want to upgrade. Possible options are:
     * leapp-data-almalinux
     * leapp-data-centos
     * leapp-data-eurolinux
@@ -58,7 +57,7 @@ sudo yum install -y leapp-upgrade leapp-data-almalinux
 * Start a preupgrade check. In the meanwhile, the Leapp utility creates a special */var/log/leapp/leapp-report.txt* file that contains possible problems and recommended solutions. No rpm packages will be installed at this phase.
 
 :::warning
-Preupgrade check will fail as the default install doesn't meet all requirements for migration.
+Preupgrade check will fail as the default install doesn't meet all requirements for upgrade.
 :::
 
 ```
@@ -94,19 +93,19 @@ sudo reboot
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
    See how the update process goes in the console.
 
-* After reboot, login to the system and check how the migration went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
 ```
 cat /etc/redhat-release
 cat /etc/os-release
-rpm -qa | grep el7 # for 7 to 8 migration
-rpm -qa | grep el8 # for 8 to 9 migration
+rpm -qa | grep el7 # for 7 to 8 upgrade
+rpm -qa | grep el8 # for 8 to 9 upgrade
 cat /var/log/leapp/leapp-report.txt
 cat /var/log/leapp/leapp-upgrade.log
 ```
 
 ### Demo Video
 
-Check Demo of a CentOS 7.x to AlmaLinux 8.x migration using the software and data provided by the AlmaLinux ELevate Project. 
+Here we have provided a demo of a CentOS 7.x to AlmaLinux 8.x upgrade using the AlmaLinux ELevate Project. 
 
 <iframe width="856" height="482" src="https://www.youtube.com/embed/Vzl9QxG5mvo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/elevate/ELevate-quickstart-guide.md
+++ b/docs/elevate/ELevate-quickstart-guide.md
@@ -13,7 +13,7 @@ Before beginning, we **HIGHLY** recommend that you follow system administration 
 This guide contains steps on how to upgrade your RHEL-based operating system to the next major version.
 
 :::tip 
-Please note that the ELevate project is designed to perform one-step upgrades. If you wish to perform an upgrade from CentOS7, you need to split the process. Please check the [ELevating CentOS7 to AlmaLinux 9](/elevate/ELevating-CentOS7-to-AlmaLinux-9.md) guide for more information.
+Please note, the ELevate project is designed to perform one-step upgrades. If you wish to perform an upgrade from CentOS7, you need to split the process. Please check the [ELevating CentOS7 to AlmaLinux 9](/elevate/ELevating-CentOS7-to-AlmaLinux-9.md) guide for more information.
 :::
 
 The ELevate supports a number of 3rd party repositories for all supported systems:

--- a/docs/elevate/ELevate-testing-guide.md
+++ b/docs/elevate/ELevate-testing-guide.md
@@ -7,26 +7,26 @@ title: "ELevate Testing Guide"
 # ELevate Testing Guide
 
 ::: warning
-Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that migration worked as expected before you attempt to migrate any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
+Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that upgrade will work as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
 :::
 
 The ELevate Project supports a number of 3rd party repositories:
-* EPEL support is currently available for the migrations to AlmaLinux OS only.
-* Imunify - for migrations to EL 8
-* KernelCare - for migrations to EL 8
+* EPEL support is currently available for upgrades to AlmaLinux OS only.
 * MariaDB - for all supported operating systems 
 * nginx - for all supported operating systems 
 * PostgreSQL - for all supported operating systems 
+* Imunify - for upgrades to EL 8
+* KernelCare - for upgrades to EL 8
 
-Currently, the following migration directions are available:
+Currently, the following upgrades are available:
 
 ![image](/images/ELevateNG.svg)
 
-\* - migration from Scientific Linux 7 to AlmaLinux 8 requires a workaround. Please, see more in the [known issues](#known-issues). <br>
-\** - migration to Oracle Linux 9 is available with the [Oracle Leapp utility](https://blogs.oracle.com/linux/post/upgrade-oracle-linux-8-to-oracle-linux-9-using-leapp) and will not be supported by ELevate project.
+\* - upgrading from Scientific Linux 7 to AlmaLinux 8 requires a workaround. Please, see more in the [known issues](#known-issues). <br>
+\** - upgrading to Oracle Linux 9 is available with the [Oracle Leapp utility](https://blogs.oracle.com/linux/post/upgrade-oracle-linux-8-to-oracle-linux-9-using-leapp) and will not be supported by ELevate project.
 
 
-## Migrate CentOS 7 to AlmaLinux 8
+## Upgrade CentOS 7 to AlmaLinux 8
 
 * Update the system to get the latest updates and reboot your machine.
    ```
@@ -40,7 +40,7 @@ Currently, the following migration directions are available:
    sudo rpm --import https://repo.almalinux.org/elevate/RPM-GPG-KEY-ELevate
    ```
 
-* Install leapp packages and migration data for AlmaLinux:  
+* Install leapp packages and upgrade data for AlmaLinux:  
    ```
    sudo yum install -y leapp-upgrade leapp-data-almalinux
    ```
@@ -48,7 +48,7 @@ Currently, the following migration directions are available:
 * Start a preupgrade check. In the meanwhile, the Leapp utility creates a special */var/log/leapp/leapp-report.txt* file that contains possible problems and recommended solutions. No rpm packages will be installed at this phase.
 
    :::warning
-   Preupgrade check will fail as the default install doesn't meet all requirements for migration.
+   Preupgrade check will fail as the default install doesn't meet all requirements for upgrading.
    :::
 
    ```
@@ -79,7 +79,7 @@ Currently, the following migration directions are available:
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
    See how the update process goes in the console.
 
-* After reboot, login to the system and check how the migration went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
   ```
   cat /etc/redhat-release
   cat /etc/os-release
@@ -88,9 +88,9 @@ Currently, the following migration directions are available:
   sudo cat /var/log/leapp/leapp-upgrade.log
   ```
 
-## Prepare the system for migration to AlmaLinux 9
+## Prepare the system for upgrading to AlmaLinux 9
 
-When successfully migrated to AlmaLinux 8 OS, consider performing these steps to prepare your system for migration to AlmaLinux 9:
+When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to prepare your system for upgrading to AlmaLinux 9:
 
 * Navigate to the **/etc/** directory and use an editor of your choice to edit the **yum.conf** file. You need to remove everything from the **exclude** line especially that refers to elevate or leapp. 
    
@@ -119,7 +119,7 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
     leapp-data-almalinux-0.2-6.el7.noarch
     leapp-0.16.0-2.el7.noarch
    ```
-   As mentioned above, consider removing these packages or upgrading them manually to proceed with migration to AlmaLinux 9.
+   As mentioned above, consider removing these packages or upgrading them manually to proceed with upgrade to AlmaLinux 9.
   
    :::tip
    If you face difficulties while removing the packages, the following command might help you:
@@ -128,7 +128,7 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
    ``` 
    :::
    
-* You can also check for the packages left from the migration process and remove them: 
+* You can also check for the packages left from the upgrade process and remove them: 
    ```   
    rpm -qa | grep elevate
    rpm -qa | grep leapp
@@ -151,16 +151,16 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
    ```
    sudo rpm -e [keyname]
    ```   
-After these preparations are completed, you can migrate your AlmaLinux 8 machine to AlmaLinux 9. 
+After these preparations are completed, you can upgrade your AlmaLinux 8 machine to AlmaLinux 9. 
 
-## Migrating AlmaLinux 8 to AlmaLinux 9
+## Upgrading AlmaLinux 8 to AlmaLinux 9
 
 * Install ELevate version 0.19.0 repo config for AlmaLinux 8:
    ```
    sudo curl https://repo.almalinux.org/elevate/testing/elevate-testing.repo -o /etc/yum.repos.d/elevate-testing.repo
    ```
 
-* Install leapp packages and migration data for AlmaLinux:  
+* Install leapp packages and upgrade data for AlmaLinux:  
    ```
    sudo yum install -y leapp-upgrade leapp-data-almalinux
    ```
@@ -168,7 +168,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
 * Start a preupgrade check. In the meanwhile, the Leapp utility creates a special */var/log/leapp/leapp-report.txt* file that contains possible problems and recommended solutions. No rpm packages will be installed at this phase.
 
    :::warning
-   Preupgrade check will fail as the default install doesn't meet all requirements for migration.
+   Preupgrade check will fail as the default install doesn't meet all requirements for upgrading.
    :::
 
    ```
@@ -187,7 +187,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
    sudo leapp answer --section check_vdo.confirm=True
    ```
    
-  You might also find the following issue in the **leapp-report** file that can interfere with the migration. Consider removing the file:
+  You might also find the following issue in the **leapp-report** file that can interfere with the upgrade. Consider removing the file:
    ```bash   
     Network configuration for unsupported device types detected
     Summary: RHEL 9 does not support the legacy network-scripts package that was deprecated in RHEL 8 in favor of NetworkManager. Files for device types that are not supported by NetworkManager are present in the system. Files with the problematic configuration:
@@ -209,7 +209,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
    See how the update process goes in the console.
 
-* After reboot, login to the system and check how the migration went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from previous OS version, consider removing them or update manually.
   ```
   cat /etc/redhat-release
   cat /etc/os-release
@@ -220,15 +220,15 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
   
 ## Demo Video
 
-Check Demo of a CentOS 7.x to AlmaLinux 8.x migration using the software and data provided by the AlmaLinux ELevate Project. 
+Here we have provided a demo of a CentOS 7.x to AlmaLinux 8.x upgrade using the AlmaLinux ELevate Project. 
 
 <iframe width="856" height="482" src="https://www.youtube.com/embed/Vzl9QxG5mvo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Known Issues
 
-### Migrating from Scientific Linux 7
+### Upgrading from Scientific Linux 7
 
-Migration from Scientific Linux 7 to AlmaLinux 8 requires a workaround. You can apply it by running the following command before the preupgrade check: 
+Upgrading from Scientific Linux 7 to AlmaLinux 8 requires a workaround. You can apply it by running the following command before the preupgrade check: 
 
   ```
   rm -rf /usr/share/redhat-release /usr/share/doc/redhat-release

--- a/docs/elevate/ELevate-testing-guide.md
+++ b/docs/elevate/ELevate-testing-guide.md
@@ -29,8 +29,10 @@ Currently, the following upgrades are available:
 ## Upgrade CentOS 7 to AlmaLinux 8
 
 * Update the system to get the latest updates and reboot your machine.
-   ```
-   sudo yum update -y
+   **NOTE:** Since the CentOS 7 repositories are now offline you will need to swap to the CentOS vault, or you can use our CentOS 7 mirror that we've setup for use with ELevate:
+   ```bash
+   curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
+   yum upgrade -y
    sudo reboot
    ```
 

--- a/docs/elevate/ELevate-testing-guide.md
+++ b/docs/elevate/ELevate-testing-guide.md
@@ -31,8 +31,8 @@ Currently, the following upgrades are available:
 * Update the system to get the latest updates and reboot your machine.
    **NOTE:** Since the CentOS 7 repositories are now offline you will need to swap to the CentOS vault, or you can use our CentOS 7 mirror that we've setup for use with ELevate:
    ```bash
-   curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
-   yum upgrade -y
+   sudo curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
+   sudo yum upgrade -y
    sudo reboot
    ```
 

--- a/docs/elevate/ELevate-testing-guide.md
+++ b/docs/elevate/ELevate-testing-guide.md
@@ -7,7 +7,7 @@ title: "ELevate Testing Guide"
 # ELevate Testing Guide
 
 ::: warning
-Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify that upgrade will work as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
+Before beginning, we **HIGHLY** recommend that you follow system administration best practices and make sure you have backups and/or snapshots of your system before you proceed. It is recommended to do a trial run in a sandbox to verify the upgrade will work as expected before you attempt to upgrade any production system. Please report any issues encountered to the [AlmaLinux Bug Tracker](https://bugs.almalinux.org) and/or [AlmaLinux Chat Migration Channel](https://chat.almalinux.org/almalinux/channels/migration)
 :::
 
 The ELevate Project supports a number of 3rd party repositories:

--- a/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
+++ b/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
@@ -15,8 +15,8 @@ As the Leapp tool is designed to perform one-step upgrades, in order to upgrade 
 * Update the system to get the latest updates and reboot your machine.
    **NOTE:** Since the CentOS 7 repositories are now offline you will need to swap to the CentOS vault, or you can use our CentOS 7 mirror that we've setup for use with ELevate:
    ```bash
-   curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
-   yum upgrade -y
+   sudo curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
+   sudo yum upgrade -y
    sudo reboot
    ```
 

--- a/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
+++ b/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
@@ -13,8 +13,10 @@ As the Leapp tool is designed to perform one-step upgrades, in order to upgrade 
 ## Upgrade CentOS 7 to AlmaLinux 8
 
 * Update the system to get the latest updates and reboot your machine.
-   ```
-   sudo yum update -y
+   **NOTE:** Since the CentOS 7 repositories are now offline you will need to swap to the CentOS vault, or you can use our CentOS 7 mirror that we've setup for use with ELevate:
+   ```bash
+   curl -o /etc/yum.repos.d/CentOS-Base.repo https://el7.repo.almalinux.org/centos/CentOS-Base.repo
+   yum upgrade -y
    sudo reboot
    ```
 

--- a/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
+++ b/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
@@ -2,15 +2,15 @@
 title: "ELevating CentOS 7 to AlmaLinux 9"
 ---
 
-###### last updated: 2024-04-18
+###### last updated: 2024-07-08
 
 # ELevating CentOS 7 to AlmaLinux 9
 
-As the Leapp tool is designed to perform one-step migrations, in order to migrate your CentOS 7 machine to AlmaLinux 9 you need to split the migration process:
+As the Leapp tool is designed to perform one-step upgrades, in order to upgrade your CentOS 7 machine to AlmaLinux 9 you need to split the upgrade process:
 * CentOS 7 to AlmaLinux 8
 * AlmaLinux 8 to AlmaLinux 9
 
-## Migrate CentOS 7 to AlmaLinux 8
+## Upgrade CentOS 7 to AlmaLinux 8
 
 * Update the system to get the latest updates and reboot your machine.
    ```
@@ -23,7 +23,7 @@ As the Leapp tool is designed to perform one-step migrations, in order to migrat
    sudo yum install -y http://repo.almalinux.org/elevate/elevate-release-latest-el$(rpm --eval %rhel).noarch.rpm
    ```
 
-* Install leapp packages and migration data for AlmaLinux:  
+* Install leapp packages and upgrade data for AlmaLinux:  
    ```
    sudo yum install -y leapp-upgrade leapp-data-almalinux
    ```
@@ -31,7 +31,7 @@ As the Leapp tool is designed to perform one-step migrations, in order to migrat
 * Start a preupgrade check. In the meanwhile, the Leapp utility creates a special */var/log/leapp/leapp-report.txt* file that contains possible problems and recommended solutions. No rpm packages will be installed at this phase.
 
    :::warning
-   Preupgrade check will fail as the default install doesn't meet all requirements for migration.
+   Preupgrade check will fail as the default install doesn't meet all requirements for upgrade.
    :::
 
    ```
@@ -62,7 +62,7 @@ As the Leapp tool is designed to perform one-step migrations, in order to migrat
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
    See how the update process goes in the console.
 
-* After reboot, login to the system and check how the migration went. Verify that the current OS is the one you need. Check logs and packages left from the previous OS version, consider removing or updating them manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from the previous OS version, consider removing or updating them manually.
    ```
    cat /etc/redhat-release
    cat /etc/os-release
@@ -71,9 +71,9 @@ As the Leapp tool is designed to perform one-step migrations, in order to migrat
    cat /var/log/leapp/leapp-upgrade.log
    ```
 
-## Prepare the system for migration to AlmaLinux 9
+## Prepare the system for upgrade to AlmaLinux 9
 
-When successfully migrated to AlmaLinux 8 OS, consider performing these steps to prepare your system for migration to AlmaLinux 9:
+When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to prepare your system for upgrade to AlmaLinux 9:
 
 * Navigate to the **/etc/** directory and use an editor of your choice to edit the **yum.conf** file. You need to remove everything from the **exclude** line especially that refers to elevate or leapp. 
    
@@ -107,7 +107,7 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
    elevate-release-1.0-2.el7.noarch
    leapp-0.14.0-1.el7.noarch
    ```
-   As mentioned above, consider removing these packages or upgrading them manually to proceed with migration to AlmaLinux 9.
+   As mentioned above, consider removing these packages or upgrading them manually to proceed with the upgrade to AlmaLinux 9.
   
    :::tip
    If you face difficulties while removing the packages, the following command might help you:
@@ -116,7 +116,7 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
    ``` 
    :::
    
-* You can also check for the packages left from the migration process and remove them: 
+* You can also check for the packages left from the upgrade process and remove them: 
    ```   
    rpm -qa | grep elevate
    rpm -qa | grep leapp
@@ -139,16 +139,16 @@ When successfully migrated to AlmaLinux 8 OS, consider performing these steps to
    ```
    rpm -e [keyname]
    ```   
-After these preparations are completed, you can migrate your AlmaLinux 8 machine to AlmaLinux 9. 
+After these preparations are completed, you can upgrade your AlmaLinux 8 machine to AlmaLinux 9. 
 
-## Migrating AlmaLinux 8 to AlmaLinux 9
+## Upgrading AlmaLinux 8 to AlmaLinux 9
 
 * Install `elevate-release` package with the project repo and GPG key.
    ```
    sudo yum install -y http://repo.almalinux.org/elevate/elevate-release-latest-el$(rpm --eval %rhel).noarch.rpm
    ```
 
-* Install leapp packages and migration data for AlmaLinux:  
+* Install leapp packages and upgrade data for AlmaLinux:  
    ```
    sudo yum install -y leapp-upgrade leapp-data-almalinux
    ```
@@ -156,7 +156,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
 * Start a preupgrade check. In the meanwhile, the Leapp utility creates a special */var/log/leapp/leapp-report.txt* file that contains possible problems and recommended solutions. No rpm packages will be installed at this phase.
 
    :::warning
-   Preupgrade check will fail as the default install doesn't meet all requirements for migration.
+   Preupgrade check will fail as the default install doesn't meet all requirements for upgrading.
    :::
 
    ```
@@ -175,7 +175,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
    sudo leapp answer --section check_vdo.no_vdo_devices=True
    ```
    
-  You might also find the following issue in the **leapp-report** file that can interfere with the migration. Consider removing the file:
+  You might also find the following issue in the **leapp-report** file that can interfere with the upgrade. Consider removing the file:
    ```bash   
     Network configuration for unsupported device types detected
     Summary: RHEL 9 does not support the legacy network-scripts package that was deprecated in RHEL 8 in favor of NetworkManager. Files for device types that are not supported by NetworkManager are present in the system. Files with the problematic configuration:
@@ -197,7 +197,7 @@ After these preparations are completed, you can migrate your AlmaLinux 8 machine
 * A new entry in GRUB called `ELevate-Upgrade-Initramfs` will appear. The system will be automatically booted into it.
    See how the update process goes in the console.
 
-* After reboot, login to the system and check how the migration went. Verify that the current OS is the one you need. Check logs and packages left from the previous OS version, consider removing or updating them manually.
+* After reboot, login to the system and check how the upgrade went. Verify that the current OS is the one you need. Check logs and packages left from the previous OS version, consider removing or updating them manually.
    ```
    cat /etc/redhat-release
    cat /etc/os-release

--- a/docs/elevate/README.md
+++ b/docs/elevate/README.md
@@ -2,15 +2,15 @@
 title: "About ELevate project"
 ---
 
-###### last updated: 2024-04-18
+###### last updated: 2024-07-08
 
 # About the project
 
-The ELevate project is an initiative to support migrations between major versions of RHEL-derivatives. 
+The ELevate project is an initiative to support upgrades between major versions of RHEL-derivatives. 
 
-The [Leapp utility](https://leapp.readthedocs.io) and a few [patches](https://github.com/AlmaLinux/leapp-repository/commits/almalinux) are used to perform in-place migrations between CentOS 7 and Enterprise Linux (EL) 8, and between EL8 and EL9 systems.
+The [Leapp utility](https://leapp.readthedocs.io) and a few [patches](https://github.com/AlmaLinux/leapp-repository/commits/almalinux) are used to perform in-place upgrades from CentOS 7 and Enterprise Linux (EL) 8, and between EL8 and EL9 systems.
 
-The [Red Hat Upgrade Tool](https://github.com/upgrades-migrations/redhat-upgrade-tool.git) is used to perform in-place migration between CentOS 6 and CentOS 7.
+The [Red Hat Upgrade Tool](https://github.com/upgrades-migrations/redhat-upgrade-tool.git) is used to perform in-place upgrades between CentOS 6 and CentOS 7.
 
 # Available migration paths 
 
@@ -22,19 +22,19 @@ The ELevate supports several 3rd party repositories for all supported systems:
 * nginx
 * PostgreSQL
 
-There are several ways to perform upgrade these days. Here is the list to see which migration directions are available:
+There are several ways to perform upgrade these days. Here is the list to see which upgrade directions are available:
 
 ![image](/images/ELevate.svg)
 
-\* - migration to CentOS Stream 9 is currently in process and will be available later. <br>
-\** - migration to Oracle Linux 9 is available with the [Oracle Leapp utility](https://blogs.oracle.com/linux/post/upgrade-oracle-linux-8-to-oracle-linux-9-using-leapp) and will not be supported by the ELevate project.
+\* - upgrading to CentOS Stream 9 is currently in process and will be available later. <br>
+\** - upgrading to Oracle Linux 9 is available with the [Oracle Leapp utility](https://blogs.oracle.com/linux/post/upgrade-oracle-linux-8-to-oracle-linux-9-using-leapp) and will not be supported by the ELevate project.
 
-# How to migrate
+# How to upgrade
 
-Various guides cover the update steps depending on the migration type:
-* The [ELevate Quickstart Guide](/elevate/ELevate-quickstart-guide) covers the update steps using the Leapp utility version with 3rd party repositories support and  provides the Demo video.
-* The [ELevate CentOS 7 to AlmaLinux 9 Guide](/elevate/ELevating-CentOS7-to-AlmaLinux-9) covers a two-stage process to migrate a CentOS 7 machine to AlmaLinux OS 9.
-* The [ELevate CentOS 6 to CentOS 7 Guide](/elevate/ELevating-CentOS6-to-CentOS7) covers steps to be performed to migrate CentOS 6 machines to CentOS 7.
+Various guides cover the update steps depending on the upgrade type:
+* The [ELevate Quickstart Guide](/elevate/ELevate-quickstart-guide) covers the update steps using the Leapp utility version with 3rd party repositories support and provides the Demo video.
+* The [ELevate CentOS 7 to AlmaLinux 9 Guide](/elevate/ELevating-CentOS7-to-AlmaLinux-9) covers a two-stage process to upgrade a CentOS 7 machine to AlmaLinux OS 9.
+* The [ELevate CentOS 6 to CentOS 7 Guide](/elevate/ELevating-CentOS6-to-CentOS7) covers steps to be performed to upgrade CentOS 6 machines to CentOS 7.
 * The [ELevate Offline Guide](/elevate/ELevate-offline-guide) covers the update steps on air-gapped machines.
 * The [ELevate NG Guide](/elevate/ELevate-NG-testing-guide) covers the update steps using the next Leapp tool version - 0.19.0.
 
@@ -44,4 +44,4 @@ The Leapp utility uses several configuration files. The biggest one is the packa
 
 # How to Contribute 
 
-ELevate is developed and built as a tool for the whole ecosystem, not just AlmaLinux. ELevate supports migrating to/from other distributions and is open for all to contribute to and enhance. You can find more information and FAQ about migration on [almalinux.org/elevate](https://almalinux.org/elevate) and [Migration SIG](/sigs/Migration), contribute using [ELevate Contribution Guide](/elevate/Contribution-guide), and get any help on [AlmaLinux Chat on Mattermost](https://chat.almalinux.org). 
+ELevate is developed and built as a tool for the whole ecosystem, not just AlmaLinux. ELevate supports upgrading to/from other distributions and is open for all to contribute to and enhance. You can find more information and FAQ on [almalinux.org/elevate](https://almalinux.org/elevate) and [Migration SIG](/sigs/Migration), contribute using [ELevate Contribution Guide](/elevate/Contribution-guide), and get any help on [AlmaLinux Chat on Mattermost](https://chat.almalinux.org). 


### PR DESCRIPTION
Two commits in this PR:

1) I've wanted to adjust our phrasing around ELevate to use upgrade instead of migrate for a while. We've had some conversations about it in various places and since I was in here doing edits I decided to take some time to do it here. If there needs to be more discussion around this language we can pull this commit back out into its own work and limit this to just the CentOS 7 repo update.

2) Adjusted the directions in these files to specifically use the new mirror.
docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
docs/elevate/ELevate-quickstart-guide.md
docs/elevate/ELevate-NG-testing-guide.md
docs/elevate/ELevate-testing-guide.md

Not covered in this PR, but we'll need to fix as well (I just don't have the technical knowledge to do the testing myself)

docs/elevate/ELevate-offline-guide.md
docs/elevate/ELevating-CentOS6-to-CentOS7.md