### PR TITLE
Reflect be2net driver modifications in 9.4 release notes

### DIFF
--- a/docs/release-notes/9.4.md
+++ b/docs/release-notes/9.4.md
@@ -58,6 +58,7 @@ Please report any issues you may encounter during tests on the [AlmaLinux Bug Tr
 * The following device drivers were modified to re-add PCI IDs for hardware that was previously disabled in our upstream:
     * **aacraid** -  Dell PERC2, 2/Si, 3/Si, 3/Di, Adaptec Advanced Raid Products, HP NetRAID-4M, IBM ServeRAID & ICP SCSI 
     * **be2iscsi** - Emulex OneConnectOpen-iSCSI for BladeEngine 2 and 3 adapters 
+    * **be2net** - Emulex BladeEngine 2 and 3 adapters *
     * **hpsa** - HP Smart Array Controller 
     * **lpfc** - Emulex LightPulse Fibre Channel SCSI 
     * **megaraid_sas** - Broadcom MegaRAID SAS 
@@ -280,11 +281,15 @@ The following devices support is added in this release, when compared with the R
 | 0x10DF:0xFD00 | HELIOS | lpfc |
 | 0x10DF:0xFD11 | HELIOS SCSP | lpfc |
 | 0x10DF:0xFD12 | HELIOS DCSP | lpfc |
+| 0x19A2:0x0211 | Emulex BladeEngine 2 Network Adapter | be2net * |
 | 0x19A2:0x0212 | Emulex BladeEngine 2 10Gb iSCSI Initiator | be2iscsi |
+| 0x19A2:0x0221 | Emulex BladeEngine 3 Network Adapter | be2net * |
 | 0x19A2:0x0222 | Emulex BladeEngine 3 iSCSI | be2iscsi |
+| 0x19A2:0x0700 | Emulex OneConnect Tigershark NIC | be2net * |
 | 0x19A2:0x0702 | Emulex OneConnect OCe10101/OCm10101/OCe10102/OCm10102 | be2iscsi |
 | 0x19A2:0x0703 | Emulex OneConnect OCe10100 | be2iscsi |
 | 0x19A2:0x0704 | Emulex OneConnect Tigershark FCoE | lpfc |
+| 0x19A2:0x0710 | Emulex OneConnect Tomcat NIC | be2net * |
 | 0x19A2:0x0712 | Emulex OneConnect Tomcat iSCSI | be2iscsi |
 | 0x19A2:0x0714 | Emulex OneConnect Tomcat FCoE | lpfc |
 | 0x9005:0x0200:0x9005:0x0200 | Themisto Jupiter Platform | aacraid |
@@ -338,6 +343,8 @@ The following devices support is added in this release, when compared with the R
 | 0x9005:0x0286:0x9005:0x0800 | Callisto Jupiter Platform | aacraid |
 | 0x9005:0x0287:0x9005:0x0800 | Themisto Jupiter Platform | aacraid |
 | 0x9005:0x0288 | Adaptec NEMER/ARK Catch All | aacraid |
+
+\* Since kernel version 5.14.0-427.18.1.el9_4
 
 ##### Trademarks
 


### PR DESCRIPTION
4 old devices support were added to be2net driver since kernel-5.14.0-427.18.1.el9_4:

0x19A2:0x0211 | Emulex BladeEngine 2 Network Adapter
0x19A2:0x0221 | Emulex BladeEngine 3 Network Adapter
0x19A2:0x0700 | Emulex OneConnect Tigershark NIC
0x19A2:0x0710 | Emulex OneConnect Tomcat NIC