### PR TITLE
ELevate Wiki Docs Updates to Include CRB Dependency Information

### DIFF
--- a/docs/elevate/ELevate-frequent-issues.md
+++ b/docs/elevate/ELevate-frequent-issues.md
@@ -126,7 +126,7 @@ After the ELevate upgrade process has completed, you may encounter an error like
 
   While this is one of the most commonly encountered post-ELevate dnf repository related issues, additional or alternative issues may arise from similarly absent dnf repositories that are responsible for dependency resolution.
 
-  To enable CRB or any other or any other AlmaLinux repository, please reference [this article](https://wiki.almalinux.org/repos/AlmaLinux.html)
+  To enable CRB or any other AlmaLinux repository, please reference [this article](/repos/AlmaLinux.html)
 
 ## Known issues 
 

--- a/docs/elevate/ELevate-frequent-issues.md
+++ b/docs/elevate/ELevate-frequent-issues.md
@@ -110,6 +110,22 @@ To resolve this issue, please, follow the steps below:
       ```
     * Navigate to the */etc/leapp/transaction/* directory to add the needed driver by writing its name and version to the **to_install** text file, for example: `kmod-3w-sas-3.26.02.000-10.el8_8.elrepo.x86_64`
 
+## dnf Updates Fail after ELevate Upgrade
+
+After the ELevate upgrade process has completed, you may encounter an error like the following when attempting to complete a dnf update...
+  ```
+  Error: 
+  Problem: package nss_db-2.34-100.el9_4.2.x86_64 from @System requires glibc(x86-64) = 2.34-100.el9_4.2, but none of the providers can be installed
+
+  cannot install both glibc-2.34-100.el9_4.2.alma.2.x86_64 from baseos and glibc-2.34-100.el9_4.2.x86_64 from @System
+  cannot install both glibc-2.34-100.el9_4.2.x86_64 from baseos and glibc-2.34-100.el9_4.2.alma.2.x86_64 from baseos
+  cannot install the best update candidate for package glibc-2.34-100.el9_4.2.x86_64
+  problem with installed package nss_db-2.34-100.el9_4.2.x86_64
+  ```
+  The cause of this error is that during the upgrade process, ELevate uses a multitude of repositories to migrate and upgrade the system. Among them is the usage of the CRB repository. Importantly, if the CRB repository was not enabled on the system prior to using ELevate, it will remain disabled after the upgrade. This can cause future system updates via dnf to fail as some packages/package dependencies now depend on the CRB repository. 
+
+  This issue can be resolved by enabling the CRB repository. Either via `crb enable` if the EPEL repository is already enabeld, or via `dnf config-manager --set-enabled crb`. After the CRB repository is enabled, the dnf cache can be cleared and dnf update should return to normal functionality.
+
 ## Known issues 
 
 * For now, the ELevate project supports only CentOS repositories. It doesn't support other third-party (external) repositories.

--- a/docs/elevate/ELevate-frequent-issues.md
+++ b/docs/elevate/ELevate-frequent-issues.md
@@ -124,7 +124,9 @@ After the ELevate upgrade process has completed, you may encounter an error like
   ```
   The cause of this error is that during the upgrade process, ELevate uses a multitude of repositories to migrate and upgrade the system. Among them is the usage of the CRB repository. Importantly, if the CRB repository was not enabled on the system prior to using ELevate, it will remain disabled after the upgrade. This can cause future system updates via dnf to fail as some packages/package dependencies now depend on the CRB repository. 
 
-  This issue can be resolved by enabling the CRB repository. Either via `crb enable` if the EPEL repository is already enabeld, or via `dnf config-manager --set-enabled crb`. After the CRB repository is enabled, the dnf cache can be cleared and dnf update should return to normal functionality.
+  While this is one of the most commonly encountered post-ELevate dnf repository related issues, additional or alternative issues may arise from similarly absent dnf repositories that are responsible for dependency resolution.
+
+  To enable CRB or any other or any other AlmaLinux repository, please reference [this article](https://wiki.almalinux.org/repos/AlmaLinux.html)
 
 ## Known issues 
 

--- a/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
+++ b/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
@@ -224,7 +224,7 @@ After these preparations are completed, you can upgrade your AlmaLinux 8 machine
 
 ## Important Notes about the Upgrade Process
 
-* During the upgrade, ELevate uses a multitude of repositories to migrate and upgrade the system. Among them is the usage of the CRB repository. Important to note, if the CRB repository was not enabled on your system prior to using ELevate, it will remain disabled after the upgrade. This can cause future system updates via dnf to fail. The errors can look something like this:
+* During the upgrade, ELevate uses a multitude of repositories to migrate and upgrade the system. Among them is the usage of the CRB repository. Important to note, if the CRB repository was not enabled on your system prior to using ELevate, it will remain disabled after the upgrade. This can cause future system updates via dnf to fail as one or more packages/package dependencies may now depend on packages within the CRB repository. The errors can look something like this:
   ```
   Error: 
   Problem: package nss_db-2.34-100.el9_4.2.x86_64 from @System requires glibc(x86-64) = 2.34-100.el9_4.2, but none of the providers can be installed
@@ -234,7 +234,7 @@ After these preparations are completed, you can upgrade your AlmaLinux 8 machine
   cannot install the best update candidate for package glibc-2.34-100.el9_4.2.x86_64
   problem with installed package nss_db-2.34-100.el9_4.2.x86_64
   ```
-  This can be resolved by enabling the CRB repository. Either via `crb enable` if the EPEL repository is already enabeld, or via `dnf config-manager --set-enabled crb`. After the CRB repository is enabled, the dnf cache can be cleared and dnf update should return to normal functionality.
+  This issue can be resolved by enabling the CRB repository. Either via `crb enable` if the EPEL repository is already enabeld, or via `dnf config-manager --set-enabled crb`. After the CRB repository is enabled, the dnf cache can be cleared and dnf update should return to normal functionality.
 
 ## Get Help 
 

--- a/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
+++ b/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
@@ -222,6 +222,20 @@ After these preparations are completed, you can upgrade your AlmaLinux 8 machine
    dnf update --allowerasing
    ```
 
+## Important Notes about the Upgrade Process
+
+* During the upgrade, ELevate uses a multitude of repositories to migrate and upgrade the system. Among them is the usage of the CRB repository. Important to note, if the CRB repository was not enabled on your system prior to using ELevate, it will remain disabled after the upgrade. This can cause future system updates via dnf to fail. The errors can look something like this:
+  ```
+  Error: 
+  Problem: package nss_db-2.34-100.el9_4.2.x86_64 from @System requires glibc(x86-64) = 2.34-100.el9_4.2, but none of the providers can be installed
+
+  cannot install both glibc-2.34-100.el9_4.2.alma.2.x86_64 from baseos and glibc-2.34-100.el9_4.2.x86_64 from @System
+  cannot install both glibc-2.34-100.el9_4.2.x86_64 from baseos and glibc-2.34-100.el9_4.2.alma.2.x86_64 from baseos
+  cannot install the best update candidate for package glibc-2.34-100.el9_4.2.x86_64
+  problem with installed package nss_db-2.34-100.el9_4.2.x86_64
+  ```
+  This can be resolved by enabling the CRB repository. Either via `crb enable` if the EPEL repository is already enabeld, or via `dnf config-manager --set-enabled crb`. After the CRB repository is enabled, the dnf cache can be cleared and dnf update should return to normal functionality.
+
 ## Get Help 
 
 For more help and assistance reach out to us in the ~migration channel on the [AlmaLinux Community Chat](https://chat.almalinux.org/almalinux/channels/migration).

--- a/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
+++ b/docs/elevate/ELevating-CentOS7-to-AlmaLinux-9.md
@@ -234,7 +234,11 @@ After these preparations are completed, you can upgrade your AlmaLinux 8 machine
   cannot install the best update candidate for package glibc-2.34-100.el9_4.2.x86_64
   problem with installed package nss_db-2.34-100.el9_4.2.x86_64
   ```
-  This issue can be resolved by enabling the CRB repository. Either via `crb enable` if the EPEL repository is already enabeld, or via `dnf config-manager --set-enabled crb`. After the CRB repository is enabled, the dnf cache can be cleared and dnf update should return to normal functionality.
+  This issue can be resolved by enabling the CRB repository.
+
+  While this is one of the most commonly encountered post-ELevate dnf repository related issues, additional or alternative issues may arise from similarly absent dnf repositories that are responsible for dependency resolution.
+
+  To enable CRB or any other AlmaLinux repository, please reference [this article](/repos/AlmaLinux.html)
 
 ## Get Help 
 


### PR DESCRIPTION
PR to address issue #477.  Includes updates to frequently encounter issues documentation and the documentation for ELevating from CentOS7 to AlmaLinux 8/9.