### PR TITLE
alesco/meeting-minutes: Fix the date for the 2024-08-21 meeting

### DIFF
--- a/docs/alesco/meeting-minutes/2024-08-21.md
+++ b/docs/alesco/meeting-minutes/2024-08-21.md
@@ -1,4 +1,4 @@
-# ALESCo Meeting Minutes (2024-07-24)
+# ALESCo Meeting Minutes (2024-08-21)
 Minutes recorded by Jonathan Wright.
 
 Edited by Jonathan Wright for publishing.


### PR DESCRIPTION
The date was incorrectly set to July 24, 2024 instead of August 21, 2024.