### PR TITLE
Adjust sidebar order to maintain ALBS being on top

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -135,8 +135,8 @@ module.exports = {
         title: 'Development',
         children: [
           '/development/AlmaLinux-Build-System',
-          '/development/building-almalinux-iso-locally',
           '/documentation/package-building-guide',
+          '/development/building-almalinux-iso-locally',
           '/development/Modified-packages',
           '/development/Packaging',
           {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -134,9 +134,9 @@ module.exports = {
      {
         title: 'Development',
         children: [
-          '/documentation/package-building-guide',
           '/development/AlmaLinux-Build-System',
           '/development/building-almalinux-iso-locally',
+          '/documentation/package-building-guide',
           '/development/Modified-packages',
           '/development/Packaging',
           {


### PR DESCRIPTION
I didn't think about the order until after #254 was merged. This should be a bit lower on the sidebar.