### PR TITLE
Added new contribute to guides

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -103,8 +103,10 @@ module.exports = {
           title: 'Contribute',
           children: [
             '/Contribute',
+            '/Contribute-to-AlmaLinux-Build-System',
             '/Contribute-to-Documentation',
             '/Mirrors',
+            '/Contribute-to-Packaging',
             '/Contribute-to-Testing',
             '/Help-translating-site',
             {

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -29,7 +29,9 @@ To contribute to development we recommend deploying the AlmaLinux Build System [
 
 ## Commit Guidelines
 
-When you are ready to create a pull request with your suggested changes, we'd like to provide some commit guidelines in order to make our commit messages consistent across all repositories around the AlmaLinux Build System. Every contributor could use this document to make commits that:
+When you are ready to create a pull request with your suggested changes, please follow the guidelines below to make our commit messages consistent across all repositories around the AlmaLinux Build System. 
+
+Every contributor should make commit messages that:
 * Make sense (grammatically).
 * Are meaningful/clear enough -> describe the change(s) made to the code.
 * Include references to Github issue (whenever possible).

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -151,7 +151,7 @@ In this structure you can see that we have used an expanded example that:
 * includes the full URL for which issue was fixed
 #### A little bit about merge commits
 
-Some commits might not be meaningul, others might not include references, some can ollow the same structure or are not fully descriptive. Since 99% of the time we merge pull requests (hereinafter PRs), we should add the relevant data in the mere commit message. By relevant data we understand the branch the code is coming from and the information we would like to know about the commits as described earlier in the document.
+Some commits might not be meaningful or might not include references to specific GitHub issues, so they cannot follow the same structure or be as fully descriptive. Since 99% of the time we merge pull requests (hereinafter PRs), we should add the relevant data in the commit message. By relevant data we mean the branch the code is coming from, and the information we would like to know about the commits as described earlier in the document, so that it can be understood later.
 
 #### Single commit PRs
 

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -155,7 +155,7 @@ Some commits might not be meaningul, others might not include references, some c
 
 #### Single commit PRs
 
-Sometimes, a PR has a single and meaningful commit message that doesn't require to reference an issue, i.e.:
+Sometimes, a PR has a single and meaningful commit message that doesn't require referencing an issue, i.e.:
 
 `Bump Pydantic from 1.10.7 to 1.10.8`
 

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -82,7 +82,7 @@ The commit message should meet the requirements:
   Resolves: https://github.com/AlmaLinux/build-system/issues/80.
   ```
 
-Ideally, every commit message should look like this, but we try to be flexible enough.
+Ideally, every commit message should look like this, but we try to be flexible enough. You can also refer to the [example](https://github.com/AlmaLinux/albs-web-server/commit/db062d4e69fe7bc93c59ce5c4c977e3fc3667419).
 
 #### Summary
 
@@ -197,6 +197,15 @@ As optional things to add, merge commit messages can also (and we encourage you 
 
 * Highlight, description or main goal of the PR.
 * Add references to fixed or resolved issues as described earlier.
+
+#### Example
+
+You can refer to this example when writing the commit. The merge [commit](https://github.com/AlmaLinux/albs-web-server/commit/7e0f7f835917fd670de6d770867fdc9720272baf) includes:
+* PR number
+* A branch being merged
+
+Since it's a 2 commits PR, linking to issue being resolved is not mandatory, as usually described in one of the commits. For single commit PRs, we can add the reference in the merge commit if it's missing. In the example, we're referencing the PR and the issue that it fixes, not the branch being merged, but anybody can go and check the branch this commit is coming from.
+
 
 ## Get Help
 

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -6,7 +6,7 @@ title: 'AlmaLinux Build System'
 
 # Contribute to AlmaLinux Build System
 
-AlmaLinux Build System is under [SIG/Build System](/sigs/Build-System) maintanance. 
+The AlmaLinux Build System is managed by the [SIG/Build System](/sigs/Build-System) SIG. 
 
 The project is open for community contributions. If you are interested to contributing the Build System project, we recommend you checking the AlmaLinux Build System project [milestones](https://github.com/AlmaLinux/build-system/milestones) for ongoing tasks and following these guidelines.
 

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -107,7 +107,7 @@ When writing the body part, you can add as much details as you want on the commi
 
 #### Footer
 
-Footer is a perfect place to add references as links to fixed or resolved issue(s). If have not referenced issues in the subject, then they can be added here:
+The footer is a perfect place to add references as links to fixed or resolved issue(s). If you have not referenced issues in the subject, then they can be added here:
 ```
 Fixes https://github.com/AlmaLinux/build-system/issues/80
 ```

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -1,0 +1,187 @@
+---
+title: 'AlmaLinux Build System'
+---
+
+###### last updated: 2024-09-20
+
+# Contribute to AlmaLinux Build System
+
+AlmaLinux Build System is under [SIG/Build System](/sigs/Build-System) maintanance. 
+
+The project is open for community contributions. If you are interested to contributing the Build System project, we recommend you checking the AlmaLinux Build System project [milestones](https://github.com/AlmaLinux/build-system/milestones) for ongoing tasks and following these guidelines.
+
+When you are ready to create a pull request with your suggested changes, please follow the **[commit guidelines](#commit-guidelines)** to keep our commit messages consistent across all repositories around the AlmaLinux Build System. 
+
+## Contribute to the codebase
+
+To contribute to development we recommend deploying the AlmaLinux Build System [locally](https://github.com/AlmaLinux/build-system/wiki/Deploy-on-local-and-remote-machines) and follow these guide steps for possible modifications and commit guidelines.
+
+#### A new service's config
+* Add template to `roles/dev_deploy/templates` for config of a service. The name of the file should be `<name_of_target_config_file>.j2`.
+* Add description of config to `roles/dev_deploy/defaults/main/configs.yml`.
+
+#### A new directory
+* Add description to `roles/dev_deploy/defaults/main/common.yml`.
+
+#### A new docker container
+* Add a new description of a container's docker image to `roles/dev_deploy/defaults/main/docker_images.yml`.
+* Add a new description of a docker container to `roles/dev_deploy/defaults/main/docker_containers.yml`.
+
+## Commit Guidelines
+
+When you are ready to create a pull request with your suggested changes, we'd like to provide some commit guidelines in order to make our commit messages consistent across all repositories around the AlmaLinux Build System. Every contributor could use this document to make commits that:
+* Make sense (grammatically).
+* Are meaningful/clear enough -> describe the change(s) made to the code.
+* Include references to Github issue (whenever possible).
+* Include references to fixed (or resolved) issue(s).
+* This guide also aims to cover not only atomic commits made by contributors but also how merge commits must be performed.
+
+### Commit messages
+For this first iteration, we aim to focus on these main two goals:
+* Commit messages must be precise about the changes made so other developers understand what happened in that commit.
+* A person can identify the ticket in Github that motivated such change. If possible link a GitHub issue that the commit(s) fixed or resolved. 
+
+**Remember**, these goals apply to both regular and merge commits.
+
+### Structure
+Depending on the context, a commit message might have specific needs in different situations, i.e.:
+
+* There is only a single commit that fixes a single issue.
+* When there is a list of meaningul commits that fixes one or several issues at a time.
+* When there's no issue involved.
+
+Even if we don't want to be very pedantic about how commits look like (unless we decide to strengthen the policy for other reasons), we'd like to be more or less consistent with the goals described above.
+
+#### A very detailed commit message
+
+The commit message should meet the requirements:
+* Should contain short (72 chars or less) summary.
+* Should contain more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
+* Further paragraphs come after blank lines.
+* Bullet points are okay, too.
+    * Typically a hyphen or asterisk is used for the bullet, followed by a single space. Use a hanging indent.
+* If want to add references to fixed or resolved issue(s), do it at the end as in the exmaple: 
+  ```
+  Fixes: https://github.com/AlmaLinux/build-system/issues/80.
+  ```
+  or 
+  ```
+  Resolves: https://github.com/AlmaLinux/build-system/issues/80.
+  ```
+
+Ideally, every commit message should look like this, but we try to be flexible enough.
+
+#### Summary
+
+Perfect summary should meet further requirements: 
+* Short commit title, 72 chars or less.
+* Commit summary, 72 chars or less per line.
+    * Keep it meaningful in a short way. Remember that you can add more details later.
+    * Using the imperative or simple past tenses is acceptable, but please be consistent.
+* Link a fixed/resolved issue:
+  ```
+  Fixes: https://github.com/AlmaLinux/build-system/issues/80
+  ```
+  or
+  ```
+  Resolves: AlmaLinux/build-system/issues/80
+  ```
+  It's optional, and can be used only when the commit message is short enough to fit in 72 characters.
+
+#### Body
+
+Body is a more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
+
+Further paragraphs come after blank lines.
+
+* Bullet points are okay, too.
+* Typically a hyphen or asterisk is used for the bullet, followed by a single space. Use a hanging indent.
+
+When writing the body part, you can add as much details as you want on the commit message. Just remember:
+* The body is optional if the subject is enough to describe the commit.
+* Wrap lines to 72 characters.
+* Using the imperative or simple past tenses is acceptable, but please be consistent.
+* Feel free to describe what you think it's worth being described as if you were your colleague (that is more or less familiar to the code) that would like to understand what happened by just reading a few lines.
+
+#### Footer
+
+Footer is a perfect place to add references as links to fixed or resolved issue(s). If have not referenced issues in the subject, then they can be added here:
+```
+Fixes https://github.com/AlmaLinux/build-system/issues/80
+```
+or 
+```
+Resolves https://github.com/AlmaLinux/build-system/issues/80
+```
+
+Remember:
+* Not having referenced issues is a possibility in case of dependency version updates and so on.
+* Can use a bullet list for the list of references.
+* Although using Github's abbreviations is okay, we privilege using the full URL as it will be meaningful if somebody is not reading the commit message through Github's interface.
+
+### Everyday Use cases
+
+#### The simplest commit message
+
+```
+Fixed create_module_by_payload (#123)
+```
+As you can see, simple commit messages like this one are ok. Even if not providing a good description in the commit message, it:
+
+* Describes that there was a fix in `create_module_by_payload`.
+* References a github issue (#123).
+
+However, this structure might not fit as `#123` will refer to issues/pull request within the same repository. That reference needs to be more specific.
+
+#### A tad more complex one
+
+```
+Added some missing AlmaLinux beta repositories
+
+We are adding missing AlmaLinux 8 RT repos for s390x and ppc64le
+Also, adding aarch64 NFV repos for AlmaLinux 9
+
+Resolves: https://github.com/AlmaLinux/build-system/issues/80
+```
+
+#### A little bit about merge commits
+
+Some commits might not be meaningul, others might not include references, some can ollow the same structure or are not fully descriptive. Since 99% of the time we merge pull requests (hereinafter PRs), we should add the relevant data in the mere commit message. By relevant data we understand the branch the code is coming from and the information we would like to know about the commits as described earlier in the document.
+
+#### Single commit PRs
+
+Sometimes, a PR has a single and meaningful commit message that doesn't require to reference an issue, i.e.:
+
+`Bump Pydantic from 1.10.7 to 1.10.8`
+
+In this case, we can do a squash and merge for the commit to end up in the repository in the following way:
+
+`Bump Pydantic from 1.10.7 to 1.10.8 (#562)`
+
+You can also create a merge commit message this way.
+```
+Merge pull request #562 from javihernandez:pydantic-1.10.8
+
+Bump Pydantic from 1.10.7 to 1.10.8
+```
+
+Of course, and as always, ensure that if the change is motivated by a Github issue, please do add a reference in the commit message as described in the previous section of the document.
+
+#### Several commits PRs
+Usually, PRs involve more than one single commit. Ideally, they all should follow the structure described through this document, but sometimes this is not the case. We can see commit messages like:
+
+* Addressed review comments.
+* Fixed typo.
+* etc.
+Which, for obvious reasons, do not provide a lot of information about the commit. For this reason, all our merge commit messages must:
+
+* Reference the branch being merged.
+* Reference the pull request.
+As optional things to add, merge commit messages can also (and we encourage to) include:
+
+* Highlight, description or main goal of the PR.
+* Add references to fixed or resolved issues as described earlier.
+
+## Get Help
+
+Join the ~SIG/Build System [chat channel](https://chat.almalinux.org/almalinux/channels/build-system) for any talk and assistance.

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -145,7 +145,10 @@ Also, adding aarch64 NFV repos for AlmaLinux 9
 
 Resolves: https://github.com/AlmaLinux/build-system/issues/80
 ```
+In this structure you can see that we have used an expanded example that:
 
+* adds more context for the changes that were made
+* includes the full URL for which issue was fixed
 #### A little bit about merge commits
 
 Some commits might not be meaningul, others might not include references, some can ollow the same structure or are not fully descriptive. Since 99% of the time we merge pull requests (hereinafter PRs), we should add the relevant data in the mere commit message. By relevant data we understand the branch the code is coming from and the information we would like to know about the commits as described earlier in the document.

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -75,7 +75,7 @@ Ideally, every commit message should look like this, but we try to be flexible e
 
 #### Summary
 
-Perfect summary should meet further requirements: 
+The perfect summary will meet these requirements: 
 * Short commit title, 72 chars or less.
 * Commit summary, 72 chars or less per line.
     * Keep it meaningful in a short way. Remember that you can add more details later.

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -41,7 +41,7 @@ Every contributor should make commit messages that:
 ### Commit messages
 For this first iteration, we aim to focus on these main two goals:
 * Commit messages must be precise about the changes made so other developers understand what happened in that commit.
-* A person can identify the ticket in Github that motivated such change. If possible link a GitHub issue that the commit(s) fixed or resolved. 
+* A person can identify the issue in Github that motivated such change. If possible link a GitHub issue that the commit(s) fixed or resolved. 
 
 **Remember**, these goals apply to both regular and merge commits.
 

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -119,7 +119,7 @@ Resolves https://github.com/AlmaLinux/build-system/issues/80
 Remember:
 * Not having referenced issues is a possibility in case of dependency version updates and so on.
 * Can use a bullet list for the list of references.
-* Although using Github's abbreviations is okay, we privilege using the full URL as it will be meaningful if somebody is not reading the commit message through Github's interface.
+* Although using Github's abbreviations is okay, we require using the full URL as it will be meaningful if somebody is not reading the commit message through Github's interface.
 
 ### Everyday Use cases
 

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -8,7 +8,7 @@ title: 'AlmaLinux Build System'
 
 The AlmaLinux Build System is managed by the [SIG/Build System](/sigs/Build-System) SIG. 
 
-The project is open for community contributions. If you are interested to contributing the Build System project, we recommend you checking the AlmaLinux Build System project [milestones](https://github.com/AlmaLinux/build-system/milestones) for ongoing tasks and following these guidelines.
+The project is open for community contributions. If you are interested to contributing the Build System project, we recommend you start by checking the AlmaLinux Build System project [milestones](https://github.com/AlmaLinux/build-system/milestones) for ongoing tasks and following the guidelines below.
 
 When you are ready to create a pull request with your suggested changes, please follow the **[commit guidelines](#commit-guidelines)** to keep our commit messages consistent across all repositories around the AlmaLinux Build System. 
 

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -2,7 +2,7 @@
 title: 'AlmaLinux Build System'
 ---
 
-###### last updated: 2024-09-20
+###### last updated: 2024-10-16
 
 # Contribute to AlmaLinux Build System
 
@@ -18,25 +18,18 @@ To contribute to development we recommend deploying the AlmaLinux Build System [
 
 ### Help Wanted
 
-We are seeking contributors to help us with:
-* Python and JavaScript Developers are needed to improve UI/UX.
-* Add the ability to run test VMs in different clouds (AWS, Azure, etc.).
-* Add the ability to use external repositories for testing scenarios (e.g. LTP for kernel, CentOS tests for different packages, openQA, etc.).
-* Add OpenStack backend driver support.
-* Add Azure backend driver support.
-* Improve ability to delete a build.
-* Add Kubevirt backend support.
+* Help on keeping our Build System SIG documentation up to date (READMEs in repos, wiki, docs, SIG wiki page, etc).
+* Testing (experience with pytest), we need help to:
+  * Increase our test coverage in repos that already have tests.
+  * Add tests to those that don't have tests at all.
+  * Design and implement integration/e2e tests that involve different services.
+* Familiar with Ansible? Help us in testing and improving our current ansible roles to deploy the AlmaLinux Build System.
+* Interested in supply-chain security and SBOM? Help us in defining the next steps toward providing and expanding the current SBOM data that AlmaLinux OS is generating.
 
-#### A new service's config
-* Add template to `roles/dev_deploy/templates` for config of a service. The name of the file should be `<name_of_target_config_file>.j2`.
-* Add description of config to `roles/dev_deploy/defaults/main/configs.yml`.
-
-#### A new directory
-* Add description to `roles/dev_deploy/defaults/main/common.yml`.
-
-#### A new docker container
-* Add a new description of a container's docker image to `roles/dev_deploy/defaults/main/docker_images.yml`.
-* Add a new description of a docker container to `roles/dev_deploy/defaults/main/docker_containers.yml`.
+Our tech stack:
+* Backend: Python, FastAPI, SQLAlchemy, PostgreSQL, Redis.
+* Frontend: JavaScript, Vue.js, Quasar.
+* Tooling: Docker, Docker Compose, Ansible, Terraform.
 
 ## Commit Guidelines
 
@@ -60,7 +53,7 @@ For this first iteration, we aim to focus on these two main goals:
 Depending on the context, a commit message might have specific needs in different situations, i.e.:
 
 * There is only a single commit that fixes a single issue.
-* When there is a list of meaningul commits that fixes one or several issues at a time.
+* When there is a list of meaningful commits that fixes one or several issues at a time.
 * When there's no issue involved.
 
 Even if we don't want to be very pedantic about how commits look (unless we decide to strengthen the policy for other reasons), we'd like to be more or less consistent with the goals described above.
@@ -157,8 +150,8 @@ Also, adding aarch64 NFV repos for AlmaLinux 9
 Resolves: https://github.com/AlmaLinux/build-system/issues/80
 ```
 In this structure you can see that we have used an expanded example that:
-* adds more context for the changes that were made
-* includes the full URL for which issue was fixed
+* adds more context to the changes that were made
+* includes the full URL for which the issue was fixed
 
 #### A little bit about merge commits
 

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -16,6 +16,17 @@ When you are ready to create a pull request with your suggested changes, please 
 
 To contribute to development we recommend deploying the AlmaLinux Build System [locally](https://github.com/AlmaLinux/build-system/wiki/Deploy-on-local-and-remote-machines) and following these guide steps for possible modifications and commit guidelines.
 
+### Help Wanted
+
+We are seeking contributors to help us with:
+* Python and JavaScript Developers are needed to improve UI/UX.
+* Add the ability to run test VMs in different clouds (AWS, Azure, etc.).
+* Add the ability to use external repositories for testing scenarios (e.g. LTP for kernel, CentOS tests for different packages, openQA, etc.).
+* Add OpenStack backend driver support.
+* Add Azure backend driver support.
+* Improve ability to delete a build.
+* Add Kubevirt backend support.
+
 #### A new service's config
 * Add template to `roles/dev_deploy/templates` for config of a service. The name of the file should be `<name_of_target_config_file>.j2`.
 * Add description of config to `roles/dev_deploy/defaults/main/configs.yml`.

--- a/docs/Contribute-to-AlmaLinux-Build-System.md
+++ b/docs/Contribute-to-AlmaLinux-Build-System.md
@@ -8,13 +8,13 @@ title: 'AlmaLinux Build System'
 
 The AlmaLinux Build System is managed by the [SIG/Build System](/sigs/Build-System) SIG. 
 
-The project is open for community contributions. If you are interested to contributing the Build System project, we recommend you start by checking the AlmaLinux Build System project [milestones](https://github.com/AlmaLinux/build-system/milestones) for ongoing tasks and following the guidelines below.
+The project is open for community contributions. If you are interested in contributing to the Build System project, we recommend you start by checking the AlmaLinux Build System project [milestones](https://github.com/AlmaLinux/build-system/milestones) for ongoing tasks and following the guidelines below.
 
 When you are ready to create a pull request with your suggested changes, please follow the **[commit guidelines](#commit-guidelines)** to keep our commit messages consistent across all repositories around the AlmaLinux Build System. 
 
 ## Contribute to the codebase
 
-To contribute to development we recommend deploying the AlmaLinux Build System [locally](https://github.com/AlmaLinux/build-system/wiki/Deploy-on-local-and-remote-machines) and follow these guide steps for possible modifications and commit guidelines.
+To contribute to development we recommend deploying the AlmaLinux Build System [locally](https://github.com/AlmaLinux/build-system/wiki/Deploy-on-local-and-remote-machines) and following these guide steps for possible modifications and commit guidelines.
 
 #### A new service's config
 * Add template to `roles/dev_deploy/templates` for config of a service. The name of the file should be `<name_of_target_config_file>.j2`.
@@ -34,14 +34,14 @@ When you are ready to create a pull request with your suggested changes, please 
 Every contributor should make commit messages that:
 * Make sense (grammatically).
 * Are meaningful/clear enough -> describe the change(s) made to the code.
-* Include references to Github issue (whenever possible).
+* Include references to a GitHub issue (whenever possible).
 * Include references to fixed (or resolved) issue(s).
 * This guide also aims to cover not only atomic commits made by contributors but also how merge commits must be performed.
 
 ### Commit messages
-For this first iteration, we aim to focus on these main two goals:
+For this first iteration, we aim to focus on these two main goals:
 * Commit messages must be precise about the changes made so other developers understand what happened in that commit.
-* A person can identify the issue in Github that motivated such change. If possible link a GitHub issue that the commit(s) fixed or resolved. 
+* A person can identify the issue in GitHub that motivated such change. If possible link a GitHub issue that the commit(s) fixed or resolved. 
 
 **Remember**, these goals apply to both regular and merge commits.
 
@@ -52,17 +52,17 @@ Depending on the context, a commit message might have specific needs in differen
 * When there is a list of meaningul commits that fixes one or several issues at a time.
 * When there's no issue involved.
 
-Even if we don't want to be very pedantic about how commits look like (unless we decide to strengthen the policy for other reasons), we'd like to be more or less consistent with the goals described above.
+Even if we don't want to be very pedantic about how commits look (unless we decide to strengthen the policy for other reasons), we'd like to be more or less consistent with the goals described above.
 
 #### A very detailed commit message
 
 The commit message should meet the requirements:
-* Should contain short (72 chars or less) summary.
+* Should contain a short (72 chars or less) summary.
 * Should contain more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
 * Further paragraphs come after blank lines.
 * Bullet points are okay, too.
     * Typically a hyphen or asterisk is used for the bullet, followed by a single space. Use a hanging indent.
-* If want to add references to fixed or resolved issue(s), do it at the end as in the exmaple: 
+* If you want to add references to fixed or resolved issue(s), do it at the end as in the example: 
   ```
   Fixes: https://github.com/AlmaLinux/build-system/issues/80.
   ```
@@ -92,18 +92,18 @@ The perfect summary will meet these requirements:
 
 #### Body
 
-Body is a more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
+The body is a more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
 
 Further paragraphs come after blank lines.
 
 * Bullet points are okay, too.
 * Typically a hyphen or asterisk is used for the bullet, followed by a single space. Use a hanging indent.
 
-When writing the body part, you can add as much details as you want on the commit message. Just remember:
+When writing the body part, you can add as many details as you want to the commit message. Just remember:
 * The body is optional if the subject is enough to describe the commit.
 * Wrap lines to 72 characters.
 * Using the imperative or simple past tenses is acceptable, but please be consistent.
-* Feel free to describe what you think it's worth being described as if you were your colleague (that is more or less familiar to the code) that would like to understand what happened by just reading a few lines.
+* Feel free to describe what you think it's worth being described as if you were your colleague (who is more or less familiar with the code) and would like to understand what happened by just reading a few lines.
 
 #### Footer
 
@@ -119,7 +119,7 @@ Resolves https://github.com/AlmaLinux/build-system/issues/80
 Remember:
 * Not having referenced issues is a possibility in case of dependency version updates and so on.
 * Can use a bullet list for the list of references.
-* Although using Github's abbreviations is okay, we require using the full URL as it will be meaningful if somebody is not reading the commit message through Github's interface.
+* Although using GitHub's abbreviations is okay, we require using the full URL as it will be meaningful if somebody is not reading the commit message through GitHub's interface.
 
 ### Everyday Use cases
 
@@ -128,10 +128,10 @@ Remember:
 ```
 Fixed create_module_by_payload (#123)
 ```
-As you can see, simple commit messages like this one are ok. Even if not providing a good description in the commit message, it:
+As you can see, simple commit messages like this one are ok. Even if it doesn't provide a good description in the commit message, it:
 
 * Describes that there was a fix in `create_module_by_payload`.
-* References a github issue (#123).
+* References a GitHub issue (#123).
 
 However, this structure might not fit as `#123` will refer to issues/pull request within the same repository. That reference needs to be more specific.
 
@@ -146,9 +146,9 @@ Also, adding aarch64 NFV repos for AlmaLinux 9
 Resolves: https://github.com/AlmaLinux/build-system/issues/80
 ```
 In this structure you can see that we have used an expanded example that:
-
 * adds more context for the changes that were made
 * includes the full URL for which issue was fixed
+
 #### A little bit about merge commits
 
 Some commits might not be meaningful or might not include references to specific GitHub issues, so they cannot follow the same structure or be as fully descriptive. Since 99% of the time we merge pull requests (hereinafter PRs), we should add the relevant data in the commit message. By relevant data we mean the branch the code is coming from, and the information we would like to know about the commits as described earlier in the document, so that it can be understood later.
@@ -170,10 +170,10 @@ Merge pull request #562 from javihernandez:pydantic-1.10.8
 Bump Pydantic from 1.10.7 to 1.10.8
 ```
 
-Of course, and as always, ensure that if the change is motivated by a Github issue, please do add a reference in the commit message as described in the previous section of the document.
+Of course, and as always, ensure that if the change is motivated by a GitHub issue, please do add a reference in the commit message as described in the previous section of the document.
 
 #### Several commits PRs
-Usually, PRs involve more than one single commit. Ideally, they all should follow the structure described through this document, but sometimes this is not the case. We can see commit messages like:
+Usually, PRs involve more than one single commit. Ideally, they all should follow the structure described in this document, but sometimes this is not the case. We can see commit messages like:
 
 * Addressed review comments.
 * Fixed typo.
@@ -182,7 +182,7 @@ Which, for obvious reasons, do not provide a lot of information about the commit
 
 * Reference the branch being merged.
 * Reference the pull request.
-As optional things to add, merge commit messages can also (and we encourage to) include:
+As optional things to add, merge commit messages can also (and we encourage you to) include:
 
 * Highlight, description or main goal of the PR.
 * Add references to fixed or resolved issues as described earlier.

--- a/docs/Contribute-to-Packaging.md
+++ b/docs/Contribute-to-Packaging.md
@@ -1,0 +1,103 @@
+---
+title: 'Packaging'
+---
+
+###### last updated: 2024-09-20
+
+# Contribute to Packaging
+
+We welcome our community to enhance to users experience by contributing to:
+
+* [Building packages for the Community](#community-repositories)
+* [Submitting patches](#submit-patches)
+
+## Community Repositories
+
+[AlmaLinux Build System](/development/AlmaLinux-Build-System) supports Community repositories. Users to create their projects and share them with others. 
+
+These packages can also be released to the [Synergy](/repos/Synergy) repository.
+
+If you are interested in building packages as a community repository, please use the [AlmaLinux Build System User Guide](https://github.com/AlmaLinux/build-system/wiki/ALBS:-Guide-for-Authorised-Users#community-repositories).
+
+## Submit patches 
+
+AlmaLinux OS source packages are stored and managed in Git repositories on [git.almalinux.org](https://git.almalinux.org/).
+
+If you'd like to submit a patch, please follow these steps: 
+
+* Login to [git.almalinux.org](https://git.almalinux.org/).
+
+* Find a package [repository](https://git.almalinux.org/explore/repos), you'd like to submit a patch for.
+
+* Fork the repository.
+
+* Apply you changes. 
+
+* When you are ready to create a pull request, please check the **[commit guidelines](#commit-guidelines)** to keep our commit messages consistent across all repositories.
+
+* The [Core SIG](/sigs/Core) members will review your patch.
+
+## Commit Guidelines
+
+When you are ready to create a pull request with your suggested changes, we'd like to provide some commit guidelines in order to make our commit messages consistent across all repositories around the AlmaLinux Build System. Every contributor could use this document to make commits that:
+* Make sense (grammatically).
+* Are meaningful/clear enough -> describe the change(s) made to the code.
+* Include references to Github issue (whenever possible).
+* Include references to fixed (or resolved) issue(s).
+* This guide also aims to cover not only atomic commits made by contributors but also how merge commits must be performed.
+
+### Commit messages
+For this first iteration, we aim to focus on these main two goals:
+* Commit messages must be precise about the changes made so other developers understand what happened in that commit.
+* A person can identify the ticket in Github that motivated such change. If possible link a GitHub issue that the commit(s) fixed or resolved. 
+
+**Remember**, these goals apply to both regular and merge commits.
+
+### Structure
+Depending on the context, a commit message might have specific needs in different situations, i.e.:
+
+* There is only a single commit that fixes a single issue.
+* When there is a list of meaningul commits that fixes one or several issues at a time.
+* When there's no issue involved.
+
+Even if we don't want to be very pedantic about how commits look like (unless we decide to strengthen the policy for other reasons), we'd like to be more or less consistent with the goals described above.
+
+#### A very detailed commit message
+
+The commit message should meet the requirements:
+* Should contain short (72 chars or less) summary.
+* Should contain more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
+* Further paragraphs come after blank lines.
+* Bullet points are okay, too.
+    * Typically a hyphen or asterisk is used for the bullet, followed by a single space. Use a hanging indent.
+
+#### Summary
+
+Perfect summary should meet further requirements: 
+* Short commit title, 72 chars or less.
+* Commit summary, 72 chars or less per line.
+    * Keep it meaningful in a short way. Remember that you can add more details later.
+    * Using the imperative or simple past tenses is acceptable, but please be consistent.
+
+It's optional, and can be used only when the commit message is short enough to fit in 72 characters.
+
+#### Body
+
+Body is a more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
+
+Further paragraphs come after blank lines.
+
+* Bullet points are okay, too.
+* Typically a hyphen or asterisk is used for the bullet, followed by a single space. Use a hanging indent.
+
+When writing the body part, you can add as much details as you want on the commit message. Just remember:
+* The body is optional if the subject is enough to describe the commit.
+* Wrap lines to 72 characters.
+* Using the imperative or simple past tenses is acceptable, but please be consistent.
+* Feel free to describe what you think it's worth being described as if you were your colleague (that is more or less familiar to the code) that would like to understand what happened by just reading a few lines.
+
+
+## Get Help
+
+Join the ~SIG/Core System [chat channel](https://chat.almalinux.org/almalinux/channels/sigcore) for any talk and assistance.
+

--- a/docs/Contribute-to-Packaging.md
+++ b/docs/Contribute-to-Packaging.md
@@ -6,7 +6,7 @@ title: 'Packaging'
 
 # Contribute to Packaging
 
-We welcome our community to enhance to users experience by contributing to:
+AlmaLinux OS is, at its base, a collection of packages. For anyone who would like to contribute to the operating system, we have a collection of ways to help!
 
 * [Building packages for the Community](#community-repositories)
 * [Submitting patches](#submit-patches)

--- a/docs/Contribute-to-Packaging.md
+++ b/docs/Contribute-to-Packaging.md
@@ -31,7 +31,7 @@ If you'd like to submit a patch, please follow these steps:
 
 * Fork the repository.
 
-* Apply you changes. 
+* Apply your changes. 
 
 * When you are ready to create a pull request, please check the **[commit guidelines](#commit-guidelines)** to keep our commit messages consistent across all repositories.
 
@@ -39,17 +39,17 @@ If you'd like to submit a patch, please follow these steps:
 
 ## Commit Guidelines
 
-When you are ready to create a pull request with your suggested changes, we'd like to provide some commit guidelines in order to make our commit messages consistent across all repositories around the AlmaLinux Build System. Every contributor could use this document to make commits that:
+When you are ready to create a pull request with your suggested changes, please follow the guidelines below to make our commit messages consistent across all repositories around the AlmaLinux Build System. Every contributor could use this document to make commits that:
 * Make sense (grammatically).
 * Are meaningful/clear enough -> describe the change(s) made to the code.
-* Include references to Github issue (whenever possible).
-* Include references to fixed (or resolved) issue(s).
+* Include references to an issue (whenever possible).
 * This guide also aims to cover not only atomic commits made by contributors but also how merge commits must be performed.
 
 ### Commit messages
-For this first iteration, we aim to focus on these main two goals:
+
+For this first iteration, we aim to focus on these two main goals:
 * Commit messages must be precise about the changes made so other developers understand what happened in that commit.
-* A person can identify the ticket in Github that motivated such change. If possible link a GitHub issue that the commit(s) fixed or resolved. 
+* A person can identify the issue that motivated such change. If possible link the issue that the commit(s) fixed or resolved. 
 
 **Remember**, these goals apply to both regular and merge commits.
 
@@ -57,15 +57,15 @@ For this first iteration, we aim to focus on these main two goals:
 Depending on the context, a commit message might have specific needs in different situations, i.e.:
 
 * There is only a single commit that fixes a single issue.
-* When there is a list of meaningul commits that fixes one or several issues at a time.
+* When there is a list of meaningful commits that fixes one or several issues at a time.
 * When there's no issue involved.
 
-Even if we don't want to be very pedantic about how commits look like (unless we decide to strengthen the policy for other reasons), we'd like to be more or less consistent with the goals described above.
+Even if we don't want to be very pedantic about how commits look (unless we decide to strengthen the policy for other reasons), we'd like to be more or less consistent with the goals described above.
 
 #### A very detailed commit message
 
 The commit message should meet the requirements:
-* Should contain short (72 chars or less) summary.
+* Should contain a short (72 chars or less) summary.
 * Should contain more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
 * Further paragraphs come after blank lines.
 * Bullet points are okay, too.
@@ -73,7 +73,7 @@ The commit message should meet the requirements:
 
 #### Summary
 
-Perfect summary should meet further requirements: 
+The perfect summary will meet these requirements: 
 * Short commit title, 72 chars or less.
 * Commit summary, 72 chars or less per line.
     * Keep it meaningful in a short way. Remember that you can add more details later.
@@ -83,18 +83,18 @@ It's optional, and can be used only when the commit message is short enough to f
 
 #### Body
 
-Body is a more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
+The body is a more detailed explanatory text. Wrap it to 72 characters. The blank line separating the summary from the body is critical (unless you omit the body entirely).
 
 Further paragraphs come after blank lines.
 
 * Bullet points are okay, too.
 * Typically a hyphen or asterisk is used for the bullet, followed by a single space. Use a hanging indent.
 
-When writing the body part, you can add as much details as you want on the commit message. Just remember:
+When writing the body part, you can add as many details as you want to the commit message. Just remember:
 * The body is optional if the subject is enough to describe the commit.
 * Wrap lines to 72 characters.
 * Using the imperative or simple past tenses is acceptable, but please be consistent.
-* Feel free to describe what you think it's worth being described as if you were your colleague (that is more or less familiar to the code) that would like to understand what happened by just reading a few lines.
+* Feel free to describe what you think it's worth being described as if you were your colleague (who is more or less familiar with the code) and would like to understand what happened by just reading a few lines.
 
 
 ## Get Help

--- a/docs/Contribute-to-Packaging.md
+++ b/docs/Contribute-to-Packaging.md
@@ -15,7 +15,7 @@ AlmaLinux OS is, at its base, a collection of packages. For anyone who would lik
 
 The [AlmaLinux Build System](/development/AlmaLinux-Build-System) supports Community repositories, allowing users to create packages of their projects and share them with others. 
 
-These packages can also be released to the [Synergy](/repos/Synergy) repository.
+If they are useful for the AlmaLinux community at large, these packages can also be released to the [Synergy](/repos/Synergy) repository. Not all packages are a good fit for Synergy, but we are happy to consider them! Once your package is building successfully, you can ask for it to be considered to be included in the [SIG/Core](https://chat.almalinux.org/almalinux/channels/sigcore) room on [chat.almalinux.org](https://chat.almalinux.org)
 
 If you are interested in building packages as a community repository, please use the [AlmaLinux Build System User Guide](https://github.com/AlmaLinux/build-system/wiki/ALBS:-Guide-for-Authorised-Users#community-repositories).
 

--- a/docs/Contribute-to-Packaging.md
+++ b/docs/Contribute-to-Packaging.md
@@ -13,7 +13,7 @@ AlmaLinux OS is, at its base, a collection of packages. For anyone who would lik
 
 ## Community Repositories
 
-[AlmaLinux Build System](/development/AlmaLinux-Build-System) supports Community repositories. Users to create their projects and share them with others. 
+The [AlmaLinux Build System](/development/AlmaLinux-Build-System) supports Community repositories, allowing users to create packages of their projects and share them with others. 
 
 These packages can also be released to the [Synergy](/repos/Synergy) repository.
 


### PR DESCRIPTION
Added 2 new guides for contributions:
1) contribute to AlmaLinux Build System https://github.com/AlmaLinux/build-system/issues/339, requires @javihernandez review
2) contribute to packageing, requires @andrewlukoshko review 

Also a general question, should we move [Contribute to ELevate ](https://wiki.almalinux.org/elevate/Contribution-guide.html) guide to this section then? Is a better place for it? 