### PR TITLE
Adding 9.5 beta release notes

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -37,6 +37,7 @@ module.exports = {
          children: [
            '/release-notes/9.4',
            '/release-notes/8.10',
+           '/release-notes/9.5-beta',
             {
             title: "Older AlmaLinux 9 releases",
   			  children: [

--- a/docs/release-notes/9.5-beta.md
+++ b/docs/release-notes/9.5-beta.md
@@ -1,0 +1,329 @@
+---
+title: '9.5 Beta'
+---
+
+###### last updated: 2024-10-15
+
+# AlmaLinux 9.5 Beta Release Notes
+
+These are the release notes for AlmaLinux OS 9.5 Beta for all supported architectures:
+* x86_64
+* aarch64
+* ppc64le
+* s390x 
+
+Codename: Teal Serval.
+
+Distributed kernel version: 5.14.0-503.2.1.el9_5
+
+## Beta Release
+
+:::warning
+This is a **BETA** release and should not be used for production installations. The provided upgrade instructions should not be used on production machines unless you have backups and a recovery option. ;)
+:::
+
+## Providing Feedback and Getting Help
+Please report any issues you may encounter during tests on the [AlmaLinux Bug Tracker](https://bugs.almalinux.org/). Additionally, if you feel like providing feedback, talking about anything or asking any questions you might want to check out [The AlmaLinux Community Chat](https://chat.almalinux.org), [The AlmaLinux Forums](https://forums.almalinux.org/c/devel/9-beta/34) and [The AlmaLinux Community on Reddit](https://reddit.com/r/almalinux).
+
+## Changelog
+
+* Compiler updates:
+    * GCC Toolset 14
+    * LLVM Toolset 18.1.3
+    * Rust Toolset 1.79.0
+    * Go Toolset 1.20.6
+    * GCC 11.5.0
+
+* Added new packages:
+    * .NET 9.0
+    * BIND 9.18
+
+* Updated module stream:
+    * Node.js 22
+
+* Performance tools and debuggers updates:
+    * GDB 14.2
+    * Valgrind 3.23.0
+    * SystemTap 5.1
+    * elfutils 0.191
+
+* Updated performance monitoring tools:
+    * PCP 6.2.2
+    * Grafana 10.2.6
+
+* Security updates:
+    * OpenSSL to version 3.2.2
+    * SELinux policy to version 38.1.44
+    * crypto-policies to version 20240822
+
+## Upgrade Instructions
+
+**Please do not use these update instructions on production machines unless you don't mind if something breaks** ;)
+
+Upgrade the almalinux-release packages to the 9.5-0.4.el9 version from the beta repositories:
+
+```bash
+$ dnf install -y https://repo.almalinux.org/vault/almalinux-{release,repos,gpg-keys}-latest-9-beta.x86_64.rpm
+$ dnf clean all
+```
+
+the new package contains updated repository URLs so that you can just run:
+
+```bash
+$ dnf upgrade -y
+```
+
+to update the rest of the packages.
+
+## Installation instructions
+
+There are three installation ISO images available:
+
+`AlmaLinux-9.5-beta-1-x86_64-boot.iso` - a single network installation CD image that downloads packages over the Internet.
+
+`AlmaLinux-9.5-beta-1-x86_64-minimal.iso` - a minimal self-containing DVD image that makes possible offline installation.
+
+`AlmaLinux-9.5-beta-1-x86_64-dvd.iso` - a full installation DVD image that contains mostly all AlmaLinux packages.
+
+Download a suitable ISO image from the 9.5-beta/isos/$arch/ directory, for example:
+
+```bash
+$ wget https://repo.almalinux.org/almalinux/9.5-beta/isos/x86_64/AlmaLinux-9.5-beta-1-x86_64-boot.iso
+```
+
+Download and import the AlmaLinux public key:
+
+```bash
+$ wget https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-9
+$ gpg --import RPM-GPG-KEY-AlmaLinux
+```
+
+Download and verify a checksums list:
+
+```bash
+$ wget https://repo.almalinux.org/almalinux/9.5-beta/isos/x86_64/CHECKSUM
+
+# we are looking for “Good signature”
+$ gpg --verify CHECKSUM
+gpg: Signature made Mon 14 Oct 2024 02:03:45 PM EDT
+gpg: Good signature from "AlmaLinux OS 9 <packager@almalinux.org>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: BF18 AC28 7617 8908 D6E7  1267 D36C B86C B86B 3716
+```
+
+Verify the downloaded ISO image checksum:
+
+```bash
+# calculate the downloaded ISO SHA256 checksum
+$ sha256sum AlmaLinux-9.5-beta-1-x86_64-boot.iso
+1360fd13a2bd4a88c5d35d7f322b9c6fc9d2eb7ea6da952c4ec7c7c860245869  AlmaLinux-9.5-beta-1-x86_64-boot.iso
+
+# compare it with expected checksum, it should be the same
+$ cat CHECKSUM | grep -E 'SHA256.*AlmaLinux-9.5-beta-1-x86_64-boot.iso'
+SHA256 (AlmaLinux-9.5-beta-1-x86_64-boot.iso) = 1360fd13a2bd4a88c5d35d7f322b9c6fc9d2eb7ea6da952c4ec7c7c860245869
+```
+
+If you decide to use the `AlmaLinux-9.5-beta-1-x86_64-boot.iso` image, you may need to provide the `https://repo.almalinux.org/vault/9.5-beta/BaseOS/x86_64/kickstart/` URL repository from the selected mirror as the Installation Source in the event that the installer is not able to find the closest mirror for some reason.
+
+There are no extra Installation Sources required if you decided to go with either the minimal or DVD ISO images.
+
+## Additional packages
+
+Here is a list of packages that are AlmaLinux-specific, and will not be found in compatible versions of RHEL.
+
+| Package | Description |
+| --- | --- |
+| almalinux-backgrounds | AlmaLinux background images.<br/>Replaces `redhat-backgrounds` |
+| almalinux-indexhtml | AlmaLinux default browser page<br/>Replaces `redhat-indexhtml` |
+| almalinux-logos | AlmaLinux graphics for OS<br/>Replaces `redhat-logos` |
+| almalinux-logos-httpd | AlmaLinux graphics for HTTPD server<br/>Replaces `redhat-logos-httpd` |
+| almalinux-logos-ipa | AlmaLinux graphics for IPA server<br/>Replaces `redhat-logos-ipa` |
+| almalinux-release | AlmaLinux release package, repos, and EULA<br/>Replaces `redhat-release` and `redhat-release-eula` |
+
+## Removed packages
+
+Here is a list of packages you will not find in AlmaLinux when comparing with the compatible version of RHEL.
+
+AlmaLinux OS is a community distribution so all changes are subject to discussion. If you would like to do so, please join [AlmaLinux Chat](https://chat.almalinux.org/almalinux/channels/engineeringpackaging) as well as filing a bug report at [AlmaLinux Bug Tracker](https://bugs.almalinux.org) to discuss if you think any of the packages below should be included into the repos.
+
+| Package | Description |
+| --- | --- |
+| insights-client | RHEL specific package to connect to upstream vendor resources |
+| kmod-redhat-* | RHEL specific modules from Driver Update Program |
+| kpatch* | RHEL specific live patches for kernel |
+| openssl-fips-provider | RHEL specific package with FIPS certified openssl binaries |
+| redhat-backgrounds | RHEL specific background images |
+| redhat-indexhtml | RHEL specific default browser page |
+| redhat-logos | RHEL specific graphics for OS |
+| redhat-logos-httpd | RHEL specific graphics for HTTPD server |
+| redhat-logos-ipa | RHEL specific graphics for IPA server |
+| redhat-release | RHEL specific release package and repos |
+| redhat-release-eula | RHEL specific EULA |
+| redhat-support-lib-python | RHEL specific package to connect to upstream vendor resources |
+| redhat-support-tool | RHEL specific package to connect to upstream vendor resources |
+| rhc | RHEL specific package to connect to upstream vendor resources |
+| rhc-worker-playbook | RHEL specific package to connect to upstream vendor resources |
+| rhsm-gtk | RHEL specific GUI for Subscription Manager |
+| rhsm-icons | RHEL specific GUI for Subscription Manager |
+| spice-client-win-x64 | Contains binaries built by upstream vendor |
+| spice-client-win-x86 | Contains binaries built by upstream vendor |
+| spice-qxl-wddm-dod | Contains binaries built by upstream vendor |
+| spice-vdagent-win-x64 | Contains binaries built by upstream vendor |
+| spice-vdagent-win-x86 | Contains binaries built by upstream vendor |
+| subscription-manager-cockpit | RHEL specific Cockpit module for Subscription Manager |
+| subscription-manager-initial-setup-addon | RHEL specific initial setup addon for Subscription Manager |
+| subscription-manager-plugin-container | RHEL specific Subscription Manager plugin for upstream vendor containers |
+| virt-who | RHEL specific package to connect to upstream vendor resources |
+| virtio-win | Contain binaries built by upstream vendor |
+
+## Extended hardware support
+
+The following devices support is added in AlmaLinux OS 9 release compared with the RHEL:
+
+| Device PCI ID | Device name | Driver name |
+| --- | --- | --- |
+| 0x0E11:*:*: \*:01:04  | Compaq | hpsa |
+| 0x1000:0x0050 | LSI SAS1064 | mptsas |
+| 0x1000:0x0054 | LSI SAS1068 | mptsas |
+| 0x1000:0x0056 | LSI SAS1064E | mptsas |
+| 0x1000:0x0058 | LSI SAS1068E | mptsas |
+| 0x1000:0x0059 | LSI SAS1068_820XELP | mptsas |
+| 0x1000:0x0060 | LSI MegaRAID SAS1078R | megaraid_sas |
+| 0x1000:0x0062 | LSI SAS1078 | mptsas |
+| 0x1000:0x0064 | LSI SAS2116_1 | mpt3sas |
+| 0x1000:0x0065 | LSI SAS2116_2 | mpt3sas |
+| 0x1000:0x0070 | LSI SAS2004 | mpt3sas |
+| 0x1000:0x0072 | LSI SAS2008 | mpt3sas |
+| 0x1000:0x0074 | LSI SAS2108_1 | mpt3sas |
+| 0x1000:0x0076 | LSI SAS2108_2 | mpt3sas |
+| 0x1000:0x0077 | LSI SAS2108_3 | mpt3sas |
+| 0x1000:0x0078 | LSI MegaRAID SAS1078 Gen2 | megaraid_sas |
+| 0x1000:0x007C | LSI MegaRAID SAS1078DE | megaraid_sas |
+| 0x1000:0x007E | LSI SSS6200 | mpt3sas |
+| 0x1000:0x0411 | LSI MegaRAID SAS1064R | megaraid_sas |
+| 0x1000:0x0413 | LSI MegaRAID SAS1068 Verde ZCR | megaraid_sas |
+| 0x1011:0x0046:0x103C:0x10C2 | HP NetRAID-4M | aacraid |
+| 0x1011:0x0046:0x9005:0x0364 | Adaptec 5400S (Mustang) | aacraid |
+| 0x1011:0x0046:0x9005:0x0365 | Adaptec 5400S (Mustang) | aacraid |
+| 0x1011:0x0046:0x9005:0x1364 | Dell PERC 2/QC | aacraid |
+| 0x1028:0x0001:0x1028:0x0001 | DELL PERC 2/Si (Iguana) | aacraid |
+| 0x1028:0x0002:0x1028:0x0002 | DELL PERC 3/Di (Opal) | aacraid |
+| 0x1028:0x0002:0x1028:0x00D1 | DELL PERC 3/Di (Viper) | aacraid |
+| 0x1028:0x0002:0x1028:0x00D9 | DELL PERC 3/Di (Lexus) | aacraid |
+| 0x1028:0x0003:0x1028:0x0003 | DELL PERC 3/Si (SlimFast) | aacraid |
+| 0x1028:0x0004:0x1028:0x00D0 | DELL PERC 3/Di (Iguana FlipChip) | aacraid |
+| 0x1028:0x000A:0x1028:0x0106 | DELL PERC 3/Di (Jaguar) | aacraid |
+| 0x1028:0x000A:0x1028:0x011B | DELL PERC 3/Di (Dagger) | aacraid |
+| 0x1028:0x000A:0x1028:0x0121 | DELL PERC 3/Di (Boxster) | aacraid |
+| 0x1028:0x0015 | Dell PERC5 | megaraid_sas |
+| 0x103C::: \*:01:04 | HP | hpsa |
+| 0x1077:0x2100 | QLogic ISP2100 | qla2xxx |
+| 0x1077:0x2200 | QLogic ISP2200 | qla2xxx |
+| 0x1077:0x2300 | QLogic ISP2300 | qla2xxx |
+| 0x1077:0x2312 | QLogic ISP2312 | qla2xxx |
+| 0x1077:0x2322 | QLogic ISP2322 | qla2xxx |
+| 0x1077:0x2422 | QLogic ISP2422 | qla2xxx |
+| 0x1077:0x2432 | QLogic ISP2432 | qla2xxx |
+| 0x1077:0x5422 | QLogic ISP5422 | qla2xxx |
+| 0x1077:0x5432 | QLogic ISP5432 / QLE220 | qla2xxx |
+| 0x1077:0x6312 | QLogic ISP6312 | qla2xxx |
+| 0x1077:0x6322 | QLogic ISP6322 | qla2xxx |
+| 0x1077:0x8001 | QLogic ISP8001 / QLE81xx | qla2xxx |
+| 0x1077:0x8021 | QLogic ISP8021 / QLE82xx | qla2xxx |
+| 0x1077:0x8022 | QLogic ISP8022 | qla4xxx |
+| 0x1077:0x8032 | QLogic ISP8324 | qla4xxx |
+| 0x1077:0x8042 | QLogic ISP8042 | qla4xxx |
+| 0x1077:0x8044 | QLogic ISP8044 / QLE84xx | qla2xxx |
+| 0x1077:0x8432 | QLogic ISP8432 / QLE8000 | qla2xxx |
+| 0x1077:0xF001 | QLogic ISPF001 / QLE10000 | qla2xxx |
+| 0x10DF:0x1AE5 | FIREFLY  | lpfc |
+| 0x10DF:0xE100 | PROTEUS VF | lpfc |
+| 0x10DF:0xE131 | BALIUS | lpfc |
+| 0x10DF:0xE180 | PROTEUS PF | lpfc |
+| 0x10DF:0xE208 | LANCER_FC_VF | lpfc |
+| 0x10DF:0xE260 | Emulex OneConnect OCe15102-FM/OCe15104-FM/OCm15108-F-P | lpfc |
+| 0x10DF:0xE268 | LANCER_FCOE_VF | lpfc |
+| 0x10DF:0xF095 | RFLY | lpfc |
+| 0x10DF:0xF098 | PFLY | lpfc |
+| 0x10DF:0xF0A1 | LP101 | lpfc |
+| 0x10DF:0xF0A5 | TFLY | lpfc |
+| 0x10DF:0xF0D1 | BSMB | lpfc |
+| 0x10DF:0xF0F5 | NEPTUNE | lpfc |
+| 0x10DF:0xF0F6 | NEPTUNE SCSP | lpfc |
+| 0x10DF:0xF0F7 | NEPTUNE DCSP | lpfc |
+| 0x10DF:0xF700 | SUPERFLY | lpfc |
+| 0x10DF:0xF800 | DRAGONFLY | lpfc |
+| 0x10DF:0xF900 | CENTAUR | lpfc |
+| 0x10DF:0xF980 | PEGASUS | lpfc |
+| 0x10DF:0xFA00 | THOR | lpfc |
+| 0x10DF:0xFB00 | VIPER | lpfc |
+| 0x10DF:0xFC00 | LP10000S | lpfc |
+| 0x10DF:0xFC10 | LP11000S | lpfc |
+| 0x10DF:0xFC20 | LPE11000S | lpfc |
+| 0x10DF:0xFC50 | PROTEUS S | lpfc |
+| 0x10DF:0xFD00 | HELIOS | lpfc |
+| 0x10DF:0xFD11 | HELIOS SCSP | lpfc |
+| 0x10DF:0xFD12 | HELIOS DCSP | lpfc |
+| 0x19A2:0x0212 | Emulex BladeEngine 2 10Gb iSCSI Initiator | be2iscsi |
+| 0x19A2:0x0222 | Emulex BladeEngine 3 iSCSI | be2iscsi |
+| 0x19A2:0x0702 | Emulex OneConnect OCe10101/OCm10101/OCe10102/OCm10102 | be2iscsi |
+| 0x19A2:0x0703 | Emulex OneConnect OCe10100 | be2iscsi |
+| 0x19A2:0x0704 | Emulex OneConnect Tigershark FCoE | lpfc |
+| 0x19A2:0x0712 | Emulex OneConnect Tomcat iSCSI | be2iscsi |
+| 0x19A2:0x0714 | Emulex OneConnect Tomcat FCoE | lpfc |
+| 0x9005:0x0200:0x9005:0x0200 | Themisto Jupiter Platform | aacraid |
+| 0x9005:0x0283:0x9005:0x0283 | Catapult | aacraid |
+| 0x9005:0x0284:0x9005:0x0284 | Tomcat | aacraid |
+| 0x9005:0x0285 | Adaptec Catch All | aacraid |
+| 0x9005:0x0285:0x1014:0x02F2 | IBM 8i (AvonPark) | aacraid |
+| 0x9005:0x0285:0x1014:0x0312 | IBM 8i (AvonPark Lite) | aacraid |
+| 0x9005:0x0285:0x1028 | Dell Catchall | aacraid |
+| 0x9005:0x0285:0x1028:0x0287 | Perc 320/DC | aacraid |
+| 0x9005:0x0285:0x1028:0x0291 | CERC SATA RAID 2 PCI SATA 6ch (DellCorsair) | aacraid |
+| 0x9005:0x0285:0x103C:0x3227 | AAR-2610SA PCI SATA 6ch | aacraid |
+| 0x9005:0x0285:0x17AA | Legend Catchall | aacraid |
+| 0x9005:0x0285:0x17AA:0x0286 | Legend S220 (Legend Crusader) | aacraid |
+| 0x9005:0x0285:0x17AA:0x0287 | Legend S230 (Legend Vulcan) | aacraid |
+| 0x9005:0x0285:0x9005:0x0285 | Adaptec 2200S (Vulcan) | aacraid |
+| 0x9005:0x0285:0x9005:0x0286 | Adaptec 2120S (Crusader) | aacraid |
+| 0x9005:0x0285:0x9005:0x0287 | Adaptec 2200S (Vulcan-2m) | aacraid |
+| 0x9005:0x0285:0x9005:0x0288 | Adaptec 3230S (Harrier) | aacraid |
+| 0x9005:0x0285:0x9005:0x0289 | Adaptec 3240S (Tornado) | aacraid |
+| 0x9005:0x0285:0x9005:0x028A | ASR-2020ZCR SCSI PCI-X ZCR (Skyhawk) | aacraid |
+| 0x9005:0x0285:0x9005:0x028B | ASR-2025ZCR SCSI SO-DIMM PCI-X ZCR (Terminator) | aacraid |
+| 0x9005:0x0285:0x9005:0x028E | ASR-2020SA SATA PCI-X ZCR (Skyhawk) | aacraid |
+| 0x9005:0x0285:0x9005:0x028F | ASR-2025SA SATA SO-DIMM PCI-X ZCR (Terminator) | aacraid |
+| 0x9005:0x0285:0x9005:0x0290 | AAR-2410SA PCI SATA 4ch (Jaguar II) | aacraid |
+| 0x9005:0x0285:0x9005:0x0292 | AAR-2810SA PCI SATA 8ch (Corsair-8) | aacraid |
+| 0x9005:0x0285:0x9005:0x0293 | AAR-21610SA PCI SATA 16ch (Corsair-16) | aacraid |
+| 0x9005:0x0285:0x9005:0x0294 | ESD SO-DIMM PCI-X SATA ZCR (Prowler) | aacraid |
+| 0x9005:0x0285:0x9005:0x0296 | ASR-2240S (SabreExpress) | aacraid |
+| 0x9005:0x0285:0x9005:0x0297 | ASR-4005 | aacraid |
+| 0x9005:0x0285:0x9005:0x0298 | ASR-4000 (BlackBird) | aacraid |
+| 0x9005:0x0285:0x9005:0x0299 | ASR-4800SAS (Marauder-X) | aacraid |
+| 0x9005:0x0285:0x9005:0x029A | ASR-4805SAS (Marauder-E) | aacraid |
+| 0x9005:0x0285:0x9005:0x02A4 | ICP9085LI (Marauder-X) | aacraid |
+| 0x9005:0x0285:0x9005:0x02A5 | ICP5085BR (Marauder-E) | aacraid |
+| 0x9005:0x0286 | Adaptec Rocket Catch All | aacraid |
+| 0x9005:0x0286:0x1014:0x9540 | IBM 8k/8k-l4 (Aurora Lite) | aacraid |
+| 0x9005:0x0286:0x1014:0x9580 | IBM 8k/8k-l8 (Aurora) | aacraid |
+| 0x9005:0x0286:0x9005:0x028C | ASR-2230S/ASR-2230SLP PCI-X (Lancer) | aacraid |
+| 0x9005:0x0286:0x9005:0x028D | ASR-2130S (Lancer) | aacraid |
+| 0x9005:0x0286:0x9005:0x029B | AAR-2820SA (Intruder) | aacraid |
+| 0x9005:0x0286:0x9005:0x029C | AAR-2620SA (Intruder) | aacraid |
+| 0x9005:0x0286:0x9005:0x029D | AAR-2420SA (Intruder) | aacraid |
+| 0x9005:0x0286:0x9005:0x029E | ICP9024RO (Lancer) | aacraid |
+| 0x9005:0x0286:0x9005:0x029F | ICP9014RO (Lancer) | aacraid |
+| 0x9005:0x0286:0x9005:0x02A0 | ICP9047MA (Lancer) | aacraid |
+| 0x9005:0x0286:0x9005:0x02A1 | ICP9087MA (Lancer) | aacraid |
+| 0x9005:0x0286:0x9005:0x02A2 | ASR-3800 (Hurricane44) | aacraid |
+| 0x9005:0x0286:0x9005:0x02A3 | ICP5445AU (Hurricane44) | aacraid |
+| 0x9005:0x0286:0x9005:0x02A6 | ICP9067MA (Intruder-6) | aacraid |
+| 0x9005:0x0286:0x9005:0x0800 | Callisto Jupiter Platform | aacraid |
+| 0x9005:0x0287:0x9005:0x0800 | Themisto Jupiter Platform | aacraid |
+| 0x9005:0x0288 | Adaptec NEMER/ARK Catch All | aacraid |
+
+##### Trademarks
+
+Red Hat and RHEL are trademarks or registered trademarks of Red Hat, Inc. or its subsidiaries in the United States and other countries.

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -12,6 +12,7 @@ Version 9 will have active support until 31 May 2027, and security support until
 
 | Release | Codename <br /> <small>[Why cats?](/FAQ.html#why-does-the-almalinux-codename-include-cats)</small> | Beta Date | Release Date | Kernel | Supported Architectures |
 |---|---|---|---|---|---|
+| [9.5](/release-notes/9.5-beta) | Teal Serval | 15 Oct 2024 | | 5.14.0-503.2.1 | x86_64, aarch64, ppc64le, s390x |
 | [9.4](/release-notes/9.4) | Seafoam Ocelot | 15 Apr 2024 | 06 May 2024 | 5.14.0-427.13.1 | x86_64, aarch64, ppc64le, s390x |
 | [9.3](/release-notes/9.3)| Shamrock Pampas Cat | 26 Oct 2023 | 13 Nov 2023 | 5.14.0-362.8.1 | x86_64, aarch64, ppc64le, s390x |
 | [9.2](/release-notes/9.2) | Turquoise Kodkod | 27 Apr 2023 | 10 May 2023 | 5.14.0-284.11.1 | x86_64, aarch64, ppc64le, s390x |


### PR DESCRIPTION
* Added 9.5 beta release notes to the release notes table in README
* As for release notes sub-menu structure, placed 9.5 beta together with current stable releases, to be moved after 9.5 stable 
![image](https://github.com/user-attachments/assets/007d38c5-1563-4212-80a0-78348cc56c30)
