### PR TITLE
Added required step to get EPEL running on Alma Linux 9

### DIFF
--- a/docs/repos/Extras.md
+++ b/docs/repos/Extras.md
@@ -30,6 +30,7 @@ dnf config-manager --set-enabled powertools
 **AlmaLinux OS 9**
 ```
 dnf config-manager --set-enabled crb
+dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 ```
 :::
 


### PR DESCRIPTION
The step is documented in [Install EPEL in 3 easy steps](https://www.redhat.com/en/blog/install-epel-linux) blog post.