### PR TITLE
Added detail to Windows Image Burning Directions

### DIFF
--- a/docs/documentation/installation-guide.md
+++ b/docs/documentation/installation-guide.md
@@ -163,7 +163,7 @@ This example is for AlmaLinux 9.1. Replace the version with the one you need to 
 
 For Windows OS there is a helpful free and open-source application - [Rufus](https://rufus.ie/). 
 
-Open the application, choose your target USB, and ISO you need to burn, and press `start`.
+Open the application, choose your target USB, and ISO you need to burn, and press `start`. After pressing start select 'DD' mode. 
 
 #### macOS
 


### PR DESCRIPTION
Added a note to use DD mode when writing images using Rufus on Windows. Using ISO mode causes the installer to fail with an error about package checksum's being incorrect.

I tried installing for the first time and ran into this problem. This reddit post suggest DD mode which worked.

https://www.reddit.com/r/AlmaLinux/comments/n2rgvj/problem_installing_alma/