### PR TITLE
Implementing auto last-updated feature

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -18,7 +18,22 @@ module.exports = {
     ['link', { rel: "shortcut icon", type: 'image/png', href: "/images/logo.png"}],
   ],
   base: '/',
+  plugins: [
+    [
+      '@vuepress/last-updated',
+      {
+        transformer: (timestamp) => {
+          return new Date(timestamp).toLocaleDateString('en-GB', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          });
+        },
+      },
+    ],
+  ],
   themeConfig: {
+    lastUpdated: 'Last Updated',
     logo: '/images/logo.png',
     nav: [
       { text: 'Home', link: 'https://almalinux.org/' },


### PR DESCRIPTION
Automating last-updated info that pulls data from git.
The timestamp format is `Last Updated: 30 January 2025` to avoid any confusion in DD/MM/YYYY, MM/DD/YYYY formats. It's placed in the left corner on the bottom of the page:
![image](https://github.com/user-attachments/assets/3feb2dfa-a128-4f68-9ab4-8050154faa7b)

The only concern I have that this broke the usage of [podman](https://wiki.almalinux.org/Contribute-to-Documentation.html#use-a-container), I failed to get the command working probably due to git access or I'm not sure, so it seems we'll need the help of @LKHN here. 

The commands that helped me check this locally:
```
export NODE_OPTIONS=--openssl-legacy-provider
npx vuepress dev docs
```