### PR TITLE
removing Darya from various SIGs

### DIFF
--- a/docs/sigs/Build-System.md
+++ b/docs/sigs/Build-System.md
@@ -54,9 +54,6 @@ Our tech stack:
 
 ## SIG Members:
 
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
-  * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
-  * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)
 * [Vasily Kleschov](mailto:vkleschov@cloudlinux.com) - Build System Team Lead.
   * Chat login: [korulag](https://chat.almalinux.org/almalinux/messages/@korulag)
   * GitHub profile: [Korulag](https://github.com/Korulag)

--- a/docs/sigs/Cloud.md
+++ b/docs/sigs/Cloud.md
@@ -78,6 +78,3 @@ If you can help, please join us at [SIG/Cloud on Mattermost](https://chat.almali
 * [Yuriy Kohut](mailto:ykohut@almalinux.org) - Release automation engineer.
   * Chat login: [ykohut](https://chat.almalinux.org/almalinux/messages/@ykohut)
   * GitHub profile: [yuravk](https://github.com/yuravk)
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
-  * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
-  * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)

--- a/docs/sigs/Core.md
+++ b/docs/sigs/Core.md
@@ -49,9 +49,6 @@ If you can help, please join us at [Core SIG on Mattermost](https://chat.almalin
 * [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - The AlmaLinux OS Lead Architect.
   * Chat login: [alukoshko](https://chat.almalinux.org/almalinux/messages/@alukoshko)
   * GitHub profile: [andrewlukoshko](https://github.com/andrewlukoshko)
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
-  * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
-  * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)
 * [Jack Aboutboul](mailto:jack@almalinux.org) - The AlmaLinux OS community manager.
   * Chat login: [themayor](https://chat.almalinux.org/almalinux/messages/@themayor)
   * GitHub profile: [jaboutboul](https://github.com/jaboutboul)

--- a/docs/sigs/Migration.md
+++ b/docs/sigs/Migration.md
@@ -62,9 +62,6 @@ If you can help, please join us at [Migration SIG on Mattermost](https://chat.al
 * [Yuriy Kohut](mailto:ykohut@almalinux.org) - ELevate Project engineer.
   * Chat login: [ykohut](https://chat.almalinux.org/almalinux/messages/@ykohut)
   * GitHub profile: [yuravk](https://github.com/yuravk)
-* [Darya Malyavkina](mailto:dmalyavkina@almalinux.org) - The director of release engineering at [CloudLinux Inc.](https://cloudlinux.com/), coordinates the company efforts on the AlmaLinux OS development and support.
-  * Chat login: [dmalyavkina](https://chat.almalinux.org/almalinux/messages/@dmalyavkina)
-  * GitHub profile: [dmalyavkina](https://github.com/dmalyavkina)
 * [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - The AlmaLinux OS Lead Architect.
   * Chat login: [alukoshko](https://chat.almalinux.org/almalinux/messages/@alukoshko)
   * GitHub profile: [andrewlukoshko](https://github.com/andrewlukoshko)

--- a/docs/sigs/sigproposaltemplate.md
+++ b/docs/sigs/sigproposaltemplate.md
@@ -29,7 +29,7 @@ Contributions take all kinds of shapes and sizes, and we welcome everyone! If yo
 
 ## SIG members
 
-* [name](either email address or mattermost chat link) - Committee lead
+* [name](either email address or mattermost chat link) - SIG lead
 * [name](either email address or mattermost chat link) - member
 
 (you can also include additional information about other folks that help your SIG or are involved in some way here)


### PR DESCRIPTION
Darya is listed as a member of many of the SIGs but is not an active member. This is leftover from the early days of AlmaLinux. This PR removes her from the lists. 