### PR TITLE
Add auto-displayed "Last Updated" on each page based on git commit

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -24,10 +24,9 @@ module.exports = {
       {
         transformer: (timestamp, lang) =>
         {
-          const moment = require('moment')
-          moment.locale(lang)
+          var dayjs = require('dayjs')
           // Omit time from last updated
-          return moment(timestamp).format("YYYY-MM-DD")
+          return dayjs(timestamp).format('YYYY-MM-DD')
         }
       }
     ]

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -18,7 +18,22 @@ module.exports = {
     ['link', { rel: "shortcut icon", type: 'image/png', href: "/images/logo.png"}],
   ],
   base: '/',
+  plugins: [
+    [
+      '@vuepress/last-updated',
+      {
+        transformer: (timestamp, lang) =>
+        {
+          const moment = require('moment')
+          moment.locale(lang)
+          // Omit time from last updated
+          return moment(timestamp).format("YYYY-MM-DD")
+        }
+      }
+    ]
+  ],
   themeConfig: {
+    lastUpdated: true,
     logo: '/images/logo.png',
     nav: [
       { text: 'Home', link: 'https://almalinux.org/' },

--- a/docs/Contribute-to-Documentation.md
+++ b/docs/Contribute-to-Documentation.md
@@ -75,7 +75,7 @@ You can use a container engine like Podman or Docker to deploy a local developme
   ```
 * Now you can create a container from this image whenever is needed from the image that was built above and mount *docs* to */wiki/docs* inside the container:
   ```sh
-  podman run --name wiki_dev --rm -i -t -p 8080:8080 -v "$(pwd)"/docs:/wiki/docs:ro,z localhost/wiki_dev
+  podman run --name wiki_dev --rm -i -t -p 8080:8080 -v "$(pwd)":/wiki:ro,z localhost/wiki_dev
   ```
   The options of the command are:
   * `podman/docker` - container engine
@@ -84,7 +84,7 @@ You can use a container engine like Podman or Docker to deploy a local developme
   * `--rm` - remove the container once it is stopped
   * `-i -t` - an interactive terminal session where you can track the deployment process and check the logs. Stop it with `Ctrl+C`.
   * `-p 8080:8080` - map the port number 8080 inside the container to 8080 on the host
-  * `-v "$(pwd)"/docs:/wiki/docs:ro,z` - mount `docs` in the current directory on `/wiki/docs` inside the container read-only (ro). **`,z` is needed only for systems that have SELinux.**
+  * `-v "$(pwd)":/wiki:ro,z` - mount the current directory (the repository root) on `/wiki` inside the container read-only (ro). **`,z` is needed only for systems that have SELinux.**
   * `localhost/wiki_dev` - the name of the container image
 * The wiki instance should be up and running on [http://localhost:8080/](http://localhost:8080/).
 * Don't forget to stop the container when you've finished. 

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   },
   "devDependencies": {
     "vuepress": "^1.9.9"
+  },
+  "dependencies": {
+    "dayjs": "^1.11.13"
   }
 }


### PR DESCRIPTION
The last updated date is shown at the bottom right.

I'm not removing the existing last updated dates at the top for now because the ones at the bottom (auto-displayed) will be updated if I commit to removing them.  Let's remove them when we make actual updates to each document.

Also [Pages style guide](https://wiki.almalinux.org/Contribute-to-Documentation.html#working-with-almalinux-documentation) must be updated if we switch to auto last-updated.

```markdown
###### last updated: YYYY-MM-DD
```

![image](https://github.com/user-attachments/assets/ce830d7d-be77-45d9-9aae-49ae68058eee)
