### PR TITLE
Remove Etcher recommendations

### DIFF
--- a/docs/LiveMedia.md
+++ b/docs/LiveMedia.md
@@ -74,6 +74,6 @@ Open the application, choose your target USB, ISO you need to burn, press start 
 
 **macOS:**
 
-The cross-platform tool [balenaEtcher](https://www.balena.io/etcher/) is used to write images on macOS. It is simple too. Open balenaEtcher, choose the image and the USB, press Flash. 
+The cross-platform tool [Fedora Media Writer](https://fedoraproject.org/workstation/download#fedora-media-writer) is used to write images on macOS. It is simple too. Open Fedora Media Writer, select the AlmaLinux ISO, choose the correct options, then write the image.
 
 More details and information about AlmaLinux Live Media can be found on [Live Media SIG](https://wiki.almalinux.org/sigs/LiveMedia.html).

--- a/docs/documentation/installation-guide.md
+++ b/docs/documentation/installation-guide.md
@@ -222,6 +222,8 @@ Choose your USB drive in the `External` section and check the disk name in the `
 ![image](/images/installation-guide-macos-usb.png)
 :::
 
+Now you have AlmaLinux ready on a USB stick.
+
 ## Installation
 
 <!---

--- a/docs/documentation/installation-guide.md
+++ b/docs/documentation/installation-guide.md
@@ -222,12 +222,6 @@ Choose your USB drive in the `External` section and check the disk name in the `
 ![image](/images/installation-guide-macos-usb.png)
 :::
 
-#### **Balena Etcher**
-
-The cross-platform tool [balenaEtcher](https://www.balena.io/etcher/) is used to write images on macOS. It is simple too. Open balenaEtcher, choose the image and the USB, and press Flash.
-
-Now you have AlmaLinux ready on a USB stick.
-
 ## Installation
 
 <!---

--- a/docs/documentation/raspberry-pi.md
+++ b/docs/documentation/raspberry-pi.md
@@ -188,7 +188,6 @@ At the time of our testing, these commands were used to fetch the images:
 The next step is to burn the image to an SD card using
 - [RPi Imager](https://www.raspberrypi.com/documentation/computers/getting-started.html#using-raspberry-pi-imager)
 - [Fedora Media Writer](https://github.com/FedoraQt/MediaWriter/releases/)
-- [balenaEtcher](https://www.balena.io/etcher/)
 - `dd`
 ...  or a tool of your choice.
 


### PR DESCRIPTION
Etcher has been [removed from the instructions for Tails](https://tails.net/news/rufus/index.en.html). It sends various information, such as IP address, filename, disk model, etc to balena servers. This PR removes Etcher from various pages.