### PR TITLE
Slight changes to snippets on releases to be more copy-pastable

### DIFF
--- a/docs/release-notes/10.0.md
+++ b/docs/release-notes/10.0.md
@@ -112,16 +112,16 @@ For a complete list of hardware support for which was added in this release, see
 
 There are three installation ISO images available:
 
-`AlmaLinux-10.0-x86_64-boot.iso` - a single network installation CD image that downloads packages over the Internet.
+`AlmaLinux-10.0-$arch-boot.iso` - a single network installation CD image that downloads packages over the Internet.
 
-`AlmaLinux-10.0-x86_64-minimal.iso` - a minimal self-containing DVD image that makes possible offline installation.
+`AlmaLinux-10.0-$arch-minimal.iso` - a minimal self-containing DVD image that makes possible offline installation.
 
-`AlmaLinux-10.0-x86_64-dvd.iso` - a full installation DVD image that contains mostly all AlmaLinux packages.
+`AlmaLinux-10.0-$arch-dvd.iso` - a full installation DVD image that contains mostly all AlmaLinux packages.
 
 Download a suitable ISO image from the 10.0/isos/$arch/ directory, for example:
 
 ```bash
-$ wget https://repo.almalinux.org/almalinux/10.0/isos/x86_64/AlmaLinux-10.0-x86_64-boot.iso
+$ wget https://repo.almalinux.org/almalinux/10.0/isos/$(uname -m)/AlmaLinux-10.0-$(uname -m)-boot.iso
 ```
 
 Download and import the AlmaLinux public key:
@@ -134,7 +134,7 @@ $ gpg --import RPM-GPG-KEY-AlmaLinux-10
 Download and verify a checksums list:
 
 ```bash
-$ wget https://repo.almalinux.org/almalinux/10.0/isos/x86_64/CHECKSUM
+$ wget https://repo.almalinux.org/almalinux/10.0/isos/$(uname -m)/CHECKSUM
 
 # we are looking for “Good signature”
 $ gpg --verify CHECKSUM
@@ -149,24 +149,24 @@ Verify the downloaded ISO image checksum:
 
 ```bash
 # calculate the downloaded ISO SHA256 checksum
-$ sha256sum AlmaLinux-10.0-x86_64-boot.iso
-a1549729bfb66a28e3546c953033c9928eae7280917bb1c490983dba3bb9941c  AlmaLinux-10.0-x86_64-boot.iso
+$ sha256sum AlmaLinux-10.0-$(uname -m)-boot.iso
+a1549729bfb66a28e3546c953033c9928eae7280917bb1c490983dba3bb9941c  AlmaLinux-10.0-x86_64-boot.iso # x86_64 checksum, yours may differ
 
 # compare it with expected checksum, it should be the same
-$ cat CHECKSUM | grep -E 'SHA256.*AlmaLinux-10.0-x86_64-boot.iso'
-SHA256 (AlmaLinux-10.0-x86_64-boot.iso) = a1549729bfb66a28e3546c953033c9928eae7280917bb1c490983dba3bb9941c
+$ cat CHECKSUM | grep -E "SHA256.*AlmaLinux-10.0-$(uname -m)-boot.iso" || echo "Warning: Checksum does not match"
+SHA256 (AlmaLinux-10.0-x86_64-boot.iso) = a1549729bfb66a28e3546c953033c9928eae7280917bb1c490983dba3bb9941c # x86_64 checksum, yours may differ
 ```
 
-If you decide to use the `AlmaLinux-10.0-x86_64-boot.iso` image, you may need to provide the `10.0/BaseOS/x86_64/kickstart/` URL repository from the selected mirror as the Installation Source in the event that the installer is not able to find the closest mirror for some reason.
+If you decide to use the `AlmaLinux-10.0-x86_64-boot.iso` image, you may need to provide the `10.0/BaseOS/x86_64/kickstart/` URL repository from the selected mirror as the *Installation Source* in the event that the installer is not able to find the closest mirror for some reason.
 
-There are no extra Installation Sources required if you decided to go with either the minimal or DVD ISO images.
+There are no extra *Installation Sources* required if you decided to go with either the minimal or DVD ISO images.
 
 ## 10.0 Beta Testers
 
 To update your AlmaLinux 0S 10.0 beta to 10.0 stable run:
 
 ```bash
-$ dnf install https://repo.almalinux.org/almalinux/almalinux-{release,repos,gpg-keys}-latest-10.$(rpm -q --qf=%{ARCH} almalinux-release).rpm
+$ dnf install https://repo.almalinux.org/almalinux/almalinux-{release,repos,gpg-keys}-latest-10.$(uname -m).rpm
 $ dnf upgrade -y
 ```
 


### PR DESCRIPTION
A few small changes to make the UX slightly better by making the snippets more copy/paste friendly (use `uname -m` over hard-coding the $arch).

- Use `uname -m` over hard-coding x86_64
- Replace use of `rpm` macro eval with same `uname -m` for consistency
- Add simple bash or (`||`) to warn user if `CHECKSUM` does not match