### PR TITLE
Update livemedia sig 2025

### DIFF
--- a/Contribute.md
+++ b/Contribute.md
@@ -1,0 +1,3 @@
+## For New Contributors
+
+If you're new to contributing, start with the [Beginner Contribution Guide](contributing/Beginner-Contribution-Guide.md).

--- a/docs/community/platforms.md
+++ b/docs/community/platforms.md
@@ -2,27 +2,19 @@
 title: 'Community Platforms'
 ---
 
-# AlmaLinux IRC Channels
+# Community Platforms
 
-AlmaLinux maintains a presence on the [freenode IRC network](https://freenode.net/).
-
-Please observe the AlmaLinux [Code of Conduct](coc.md) and respect your fellow users at all times.
+The AlmaLinux community communicates through modern platforms that are open, transparent, and actively maintained. Join us and get involved!
 
 ## Official Channels
 
-| Channel | Purpose |
+| Platform | Purpose |
 |-|-|
-| #almalinux | General discussion and community-based user support |
-| #almalinux-arm | (SIG) ARM-specific discussion and support
-| #almalinux-cloud | (SIG) Cloud-centric discussion (AWS, GCP, Azure, OpenStack, etc.) |
-| #almalinux-devel | Developing for AlmaLinux (or a similar EL platform)? This is for you. |
-| #almalinux-infra | Discussion or issue reporting for AlmaLinux project infrastructure |
-| #almalinux-security | Security-specific discussion and support |
-| #almalinux-social | Off-topic banter |
-| #almalinux-storage | (SIG) Storage-specific discussion (GlusterFS, etc.)
+| [Matrix](https://matrix.to/#/#almalinux:matrix.org) | Real-time chat and support (primary communication channel) |
+| [Discourse Forum](https://almalinux.discourse.group/) | Long-form discussions, community collaboration |
+| [GitHub Discussions](https://github.com/AlmaLinux/wiki/discussions) | Q&A, feedback, and wiki contributions |
+| [Reddit](https://www.reddit.com/r/AlmaLinux/) | Informal discussions and community interaction |
+| [Mailing Lists](https://lists.almalinux.org/) | Formal announcements, SIG coordination, and proposals |
 
-# Mattermost
+IRC and Mattermost are no longer actively maintained and have been deprecated in favor of the platforms above.
 
-AlmaLinux operates a Mattermost instance at https://chat.almalinux.org.
-
-This instance is open to the public; contributors are highly encouraged to sign up!

--- a/docs/contributing/Beginner-Contribution-Guide.md
+++ b/docs/contributing/Beginner-Contribution-Guide.md
@@ -1,0 +1,80 @@
+
+# 🐧 Beginner's Guide to Contributing to the AlmaLinux Wiki
+
+Welcome! This guide will help you make your **first contribution** to the AlmaLinux Wiki.
+
+## 🎯 What Is the AlmaLinux Wiki?
+
+The AlmaLinux Wiki provides documentation, guidelines, community links, and technical resources for AlmaLinux OS — a free, open-source, RHEL-compatible Linux distribution maintained by the community.
+
+## 🛠 Prerequisites
+
+- GitHub account
+- Git installed on your system
+- Basic Markdown knowledge
+- Familiarity with GitHub Pull Requests
+
+## 🚀 How to Contribute
+
+### 1. Fork and Clone the Repository
+
+```bash
+git clone https://github.com/YOUR_USERNAME/wiki.git
+cd wiki
+```
+
+### 2. Create a Feature Branch
+
+```bash
+git checkout -b add-my-contribution
+```
+
+### 3. Make Your Changes
+
+You can:
+- Add or improve documentation pages
+- Fix typos, grammar, or formatting
+- Update community or resource links
+- Translate content to other languages
+
+### 4. Test Your Changes
+
+Run the following to make sure your changes render properly:
+
+```bash
+yarn install
+yarn docs:dev
+```
+
+Visit `http://localhost:3000` in your browser to review the documentation locally.
+
+### 5. Commit and Push
+
+```bash
+git add .
+git commit -m "Add beginner guide to contributing"
+git push origin add-my-contribution
+```
+
+### 6. Create a Pull Request
+
+Go to your forked repository on GitHub and open a Pull Request against the `main` branch of [AlmaLinux/wiki](https://github.com/AlmaLinux/wiki).
+
+Please include a clear explanation of the changes you made.
+
+## 🙋 Where to Ask Questions
+
+If you get stuck:
+- Join the [Mattermost Chat](https://chat.almalinux.org)
+- Visit the [Community Forum](https://forums.almalinux.org)
+- Ask in [Reddit](https://www.reddit.com/r/AlmaLinux/)
+- Or post your question in the relevant GitHub Issue
+
+## 📄 License
+
+By contributing, you agree that your content will be released under the [CC-BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
+
+---
+
+Thank you for helping improve AlmaLinux! 💙
+

--- a/docs/contributing/Beginner-Contribution-Guide.md
+++ b/docs/contributing/Beginner-Contribution-Guide.md
@@ -1,80 +1,27 @@
-
-# 🐧 Beginner's Guide to Contributing to the AlmaLinux Wiki
+# Beginner's Guide to Contributing to the AlmaLinux Wiki
 
 Welcome! This guide will help you make your **first contribution** to the AlmaLinux Wiki.
 
-## 🎯 What Is the AlmaLinux Wiki?
+## What Is the AlmaLinux Wiki?
 
 The AlmaLinux Wiki provides documentation, guidelines, community links, and technical resources for AlmaLinux OS — a free, open-source, RHEL-compatible Linux distribution maintained by the community.
 
-## 🛠 Prerequisites
+## Prerequisites
 
-- GitHub account
-- Git installed on your system
-- Basic Markdown knowledge
-- Familiarity with GitHub Pull Requests
+- [GitHub account](https://docs.github.com/en/get-started/signing-up-for-github)
+- [Git installed on your system](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Basic Markdown knowledge](https://www.markdownguide.org/basic-syntax/)
+- [Familiarity with GitHub Pull Requests](https://docs.github.com/en/pull-requests)
 
-## 🚀 How to Contribute
+## How to Contribute
 
 ### 1. Fork and Clone the Repository
+
+First, fork the [AlmaLinux/wiki](https://github.com/AlmaLinux/wiki) repository on GitHub by clicking the **Fork** button in the top-right corner of the page.
+
+Then, clone your fork locally:
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/wiki.git
 cd wiki
-```
-
-### 2. Create a Feature Branch
-
-```bash
-git checkout -b add-my-contribution
-```
-
-### 3. Make Your Changes
-
-You can:
-- Add or improve documentation pages
-- Fix typos, grammar, or formatting
-- Update community or resource links
-- Translate content to other languages
-
-### 4. Test Your Changes
-
-Run the following to make sure your changes render properly:
-
-```bash
-yarn install
-yarn docs:dev
-```
-
-Visit `http://localhost:3000` in your browser to review the documentation locally.
-
-### 5. Commit and Push
-
-```bash
-git add .
-git commit -m "Add beginner guide to contributing"
-git push origin add-my-contribution
-```
-
-### 6. Create a Pull Request
-
-Go to your forked repository on GitHub and open a Pull Request against the `main` branch of [AlmaLinux/wiki](https://github.com/AlmaLinux/wiki).
-
-Please include a clear explanation of the changes you made.
-
-## 🙋 Where to Ask Questions
-
-If you get stuck:
-- Join the [Mattermost Chat](https://chat.almalinux.org)
-- Visit the [Community Forum](https://forums.almalinux.org)
-- Ask in [Reddit](https://www.reddit.com/r/AlmaLinux/)
-- Or post your question in the relevant GitHub Issue
-
-## 📄 License
-
-By contributing, you agree that your content will be released under the [CC-BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
-
----
-
-Thank you for helping improve AlmaLinux! 💙
 

--- a/docs/sigs/LiveMedia.md
+++ b/docs/sigs/LiveMedia.md
@@ -1,45 +1,40 @@
 ---
 title: "Live Media SIG"
 ---
+
 # Live Media SIG
 
-The Live Media Team is responsible for AlmaLinux OS Live Media.
+The Live Media SIG is responsible for creating and maintaining AlmaLinux OS Live ISO images for multiple desktop environments (GNOME, KDE, XFCE, etc.).
 
 ## How to Join
 
-Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
+Anyone is welcome to contribute! You can join our discussion on Matrix or contribute directly via GitHub.
 
-**Where we chat**
+- **Chat**: [#almalinux:matrix.org](https://matrix.to/#/#almalinux:matrix.org)
+- **GitHub Repository**: [AlmaLinux/sig-livemedia](https://github.com/AlmaLinux/sig-livemedia)
 
-The Live Media SIG uses the [SIG/LiveMedia](https://chat.almalinux.org/almalinux/channels/siglivemedia) chat channel for communication.
+## Activities and Deliverables (2025)
 
-**Where and when we meet**
+- Provide Live ISO images for AlmaLinux 9 and AlmaLinux 10
+- Maintain and test multiple spins (GNOME, KDE, XFCE)
+- Automate build and test processes using CI/CD pipelines
+- Collaborate with Infrastructure SIG to host and distribute official images
 
-We do not currently hold regular meetings, but work asynchronously in mattermost to accomplish our goals.
+**Download ISO Images**
 
-## Activities, projects, and deliverables
+- AlmaLinux 8: [repo.almalinux.org/almalinux/8/live/x86_64](https://repo.almalinux.org/almalinux/8/live/x86_64/)
+- AlmaLinux 9: [repo.almalinux.org/almalinux/9/live/x86_64](https://repo.almalinux.org/almalinux/9/live/x86_64/)
+- AlmaLinux 10: [repo.almalinux.org/almalinux/10/live/x86_64](https://repo.almalinux.org/almalinux/10/live/x86_64/) *(Work in progress)*
 
-* ISO images download link: [repo.almalinux.org/almalinux/8/live/x86_64](https://repo.almalinux.org/almalinux/8/live/x86_64/).
-* Build scripts and configuration files: [AlmaLinux/sig-livemedia](https://github.com/AlmaLinux/sig-livemedia).
+## Help Wanted
 
-### Help wanted
+- CI/CD engineers to improve build pipeline
+- Testers for verifying ISO functionality across environments
+- Technical writers for documentation and release notes
 
-* Technical writers for working on documentation.
-* Design and automate test scenarios.
+## SIG Members
 
-If you can help, please join us at [Live Media SIG on Mattermost](https://chat.almalinux.org/almalinux/channels/siglivemedia) 
-
-## SIG members
-
-* [Eduard Abdullin](mailto:eabdullin@almalinux.org) - Works on Live Media build scripts and configuration files.
-  * Chat login: [eabdullin](https://chat.almalinux.org/almalinux/messages/@eabdullin)
-  * GitHub profile: [eabdullin1](https://github.com/eabdullin1)
-* [Elkhan Mammadli](mailto:elkhan.mammadli@protonmail.com) - Works on Live Media build scripts and automation.
-  * Chat login: [lkhn](https://chat.almalinux.org/almalinux/messages/@lkhn)
-  * GitHub profile: [LKHN](https://github.com/LKHN)
-* [Yuriy Kohut](mailto:ykohut@almalinux.org) - Works on Live Media build scripts and configuration files.
-  * Chat login: [ykohut](https://chat.almalinux.org/almalinux/messages/@ykohut)
-  * GitHub profile: [yuravk](https://github.com/yuravk)
-* [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - The AlmaLinux OS Lead Architect.
-  * Chat login: [alukoshko](https://chat.almalinux.org/almalinux/messages/@alukoshko)
-  * GitHub profile: [andrewlukoshko](https://github.com/andrewlukoshko)
+- Eduard Abdullin ([GitHub](https://github.com/eabdullin1))
+- Elkhan Mammadli ([GitHub](https://github.com/LKHN))
+- Yuriy Kohut ([GitHub](https://github.com/yuravk))
+- Andrew Lukoshko – AlmaLinux OS Lead Architect ([GitHub](https://github.com/andrewlukoshko))


### PR DESCRIPTION
This PR updates the LiveMedia SIG documentation to reflect the current status as of 2025:

- Adds support references for AlmaLinux 9 and 10 Live ISOs
- Updates communication channels to Matrix
- Describes ongoing CI/CD and automation goals
- Modernizes SIG member references

Relates to #420 for future i18n alignment.
