### PR TITLE
Update Marketing SIG documentation to reflect 2025 communication strategy

### DIFF
--- a/Contribute.md
+++ b/Contribute.md
@@ -1,0 +1,3 @@
+## For New Contributors
+
+If you're new to contributing, start with the [Beginner Contribution Guide](contributing/Beginner-Contribution-Guide.md).

--- a/docs/community/platforms.md
+++ b/docs/community/platforms.md
@@ -2,27 +2,19 @@
 title: 'Community Platforms'
 ---
 
-# AlmaLinux IRC Channels
+# Community Platforms
 
-AlmaLinux maintains a presence on the [freenode IRC network](https://freenode.net/).
-
-Please observe the AlmaLinux [Code of Conduct](coc.md) and respect your fellow users at all times.
+The AlmaLinux community communicates through modern platforms that are open, transparent, and actively maintained. Join us and get involved!
 
 ## Official Channels
 
-| Channel | Purpose |
+| Platform | Purpose |
 |-|-|
-| #almalinux | General discussion and community-based user support |
-| #almalinux-arm | (SIG) ARM-specific discussion and support
-| #almalinux-cloud | (SIG) Cloud-centric discussion (AWS, GCP, Azure, OpenStack, etc.) |
-| #almalinux-devel | Developing for AlmaLinux (or a similar EL platform)? This is for you. |
-| #almalinux-infra | Discussion or issue reporting for AlmaLinux project infrastructure |
-| #almalinux-security | Security-specific discussion and support |
-| #almalinux-social | Off-topic banter |
-| #almalinux-storage | (SIG) Storage-specific discussion (GlusterFS, etc.)
+| [Matrix](https://matrix.to/#/#almalinux:matrix.org) | Real-time chat and support (primary communication channel) |
+| [Discourse Forum](https://almalinux.discourse.group/) | Long-form discussions, community collaboration |
+| [GitHub Discussions](https://github.com/AlmaLinux/wiki/discussions) | Q&A, feedback, and wiki contributions |
+| [Reddit](https://www.reddit.com/r/AlmaLinux/) | Informal discussions and community interaction |
+| [Mailing Lists](https://lists.almalinux.org/) | Formal announcements, SIG coordination, and proposals |
 
-# Mattermost
+IRC and Mattermost are no longer actively maintained and have been deprecated in favor of the platforms above.
 
-AlmaLinux operates a Mattermost instance at https://chat.almalinux.org.
-
-This instance is open to the public; contributors are highly encouraged to sign up!

--- a/docs/contributing/Beginner-Contribution-Guide.md
+++ b/docs/contributing/Beginner-Contribution-Guide.md
@@ -1,0 +1,80 @@
+
+# 🐧 Beginner's Guide to Contributing to the AlmaLinux Wiki
+
+Welcome! This guide will help you make your **first contribution** to the AlmaLinux Wiki.
+
+## 🎯 What Is the AlmaLinux Wiki?
+
+The AlmaLinux Wiki provides documentation, guidelines, community links, and technical resources for AlmaLinux OS — a free, open-source, RHEL-compatible Linux distribution maintained by the community.
+
+## 🛠 Prerequisites
+
+- GitHub account
+- Git installed on your system
+- Basic Markdown knowledge
+- Familiarity with GitHub Pull Requests
+
+## 🚀 How to Contribute
+
+### 1. Fork and Clone the Repository
+
+```bash
+git clone https://github.com/YOUR_USERNAME/wiki.git
+cd wiki
+```
+
+### 2. Create a Feature Branch
+
+```bash
+git checkout -b add-my-contribution
+```
+
+### 3. Make Your Changes
+
+You can:
+- Add or improve documentation pages
+- Fix typos, grammar, or formatting
+- Update community or resource links
+- Translate content to other languages
+
+### 4. Test Your Changes
+
+Run the following to make sure your changes render properly:
+
+```bash
+yarn install
+yarn docs:dev
+```
+
+Visit `http://localhost:3000` in your browser to review the documentation locally.
+
+### 5. Commit and Push
+
+```bash
+git add .
+git commit -m "Add beginner guide to contributing"
+git push origin add-my-contribution
+```
+
+### 6. Create a Pull Request
+
+Go to your forked repository on GitHub and open a Pull Request against the `main` branch of [AlmaLinux/wiki](https://github.com/AlmaLinux/wiki).
+
+Please include a clear explanation of the changes you made.
+
+## 🙋 Where to Ask Questions
+
+If you get stuck:
+- Join the [Mattermost Chat](https://chat.almalinux.org)
+- Visit the [Community Forum](https://forums.almalinux.org)
+- Ask in [Reddit](https://www.reddit.com/r/AlmaLinux/)
+- Or post your question in the relevant GitHub Issue
+
+## 📄 License
+
+By contributing, you agree that your content will be released under the [CC-BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
+
+---
+
+Thank you for helping improve AlmaLinux! 💙
+

--- a/docs/contributing/Beginner-Contribution-Guide.md
+++ b/docs/contributing/Beginner-Contribution-Guide.md
@@ -1,80 +1,27 @@
-
-# 🐧 Beginner's Guide to Contributing to the AlmaLinux Wiki
+# Beginner's Guide to Contributing to the AlmaLinux Wiki
 
 Welcome! This guide will help you make your **first contribution** to the AlmaLinux Wiki.
 
-## 🎯 What Is the AlmaLinux Wiki?
+## What Is the AlmaLinux Wiki?
 
 The AlmaLinux Wiki provides documentation, guidelines, community links, and technical resources for AlmaLinux OS — a free, open-source, RHEL-compatible Linux distribution maintained by the community.
 
-## 🛠 Prerequisites
+## Prerequisites
 
-- GitHub account
-- Git installed on your system
-- Basic Markdown knowledge
-- Familiarity with GitHub Pull Requests
+- [GitHub account](https://docs.github.com/en/get-started/signing-up-for-github)
+- [Git installed on your system](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Basic Markdown knowledge](https://www.markdownguide.org/basic-syntax/)
+- [Familiarity with GitHub Pull Requests](https://docs.github.com/en/pull-requests)
 
-## 🚀 How to Contribute
+## How to Contribute
 
 ### 1. Fork and Clone the Repository
+
+First, fork the [AlmaLinux/wiki](https://github.com/AlmaLinux/wiki) repository on GitHub by clicking the **Fork** button in the top-right corner of the page.
+
+Then, clone your fork locally:
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/wiki.git
 cd wiki
-```
-
-### 2. Create a Feature Branch
-
-```bash
-git checkout -b add-my-contribution
-```
-
-### 3. Make Your Changes
-
-You can:
-- Add or improve documentation pages
-- Fix typos, grammar, or formatting
-- Update community or resource links
-- Translate content to other languages
-
-### 4. Test Your Changes
-
-Run the following to make sure your changes render properly:
-
-```bash
-yarn install
-yarn docs:dev
-```
-
-Visit `http://localhost:3000` in your browser to review the documentation locally.
-
-### 5. Commit and Push
-
-```bash
-git add .
-git commit -m "Add beginner guide to contributing"
-git push origin add-my-contribution
-```
-
-### 6. Create a Pull Request
-
-Go to your forked repository on GitHub and open a Pull Request against the `main` branch of [AlmaLinux/wiki](https://github.com/AlmaLinux/wiki).
-
-Please include a clear explanation of the changes you made.
-
-## 🙋 Where to Ask Questions
-
-If you get stuck:
-- Join the [Mattermost Chat](https://chat.almalinux.org)
-- Visit the [Community Forum](https://forums.almalinux.org)
-- Ask in [Reddit](https://www.reddit.com/r/AlmaLinux/)
-- Or post your question in the relevant GitHub Issue
-
-## 📄 License
-
-By contributing, you agree that your content will be released under the [CC-BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
-
----
-
-Thank you for helping improve AlmaLinux! 💙
 

--- a/docs/sigs/Infrastructure.md
+++ b/docs/sigs/Infrastructure.md
@@ -1,72 +1,46 @@
 ---
 title: "Infrastructure SIG"
 ---
+
 # Infrastructure SIG
 
-The infrastructure team is responsible for maintaining the servers and services that keep AlmaLinux online and accessible to end users.
+The Infrastructure SIG is responsible for building, maintaining, and evolving the technical infrastructure that powers the AlmaLinux OS project.
+
+This includes systems used by developers, contributors, mirrors, and users around the world.
+
+## Scope of Work (as of 2025)
+
+- Maintain the [AlmaLinux Build System (ALBS)](https://build.almalinux.org/) for reproducible builds
+- Manage and scale the global mirror infrastructure ([mirrors.almalinux.org](https://mirrors.almalinux.org))
+- Automate package pipeline builds and ISO generation
+- Provide CI/CD pipelines for SIGs and developers
+- Maintain [repo.almalinux.org](https://repo.almalinux.org) and associated package hosting
+- Monitor uptime, performance, and availability of all community services
+- Assist other SIGs with infrastructure support
 
 ## How to Join
 
-Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
+If you're interested in DevOps, automation, monitoring, or packaging infrastructure, we welcome contributions!
 
-**Where we chat**
+- **Chat**: [#almalinux:matrix.org](https://matrix.to/#/#almalinux:matrix.org)
+- **GitHub Repository**: [AlmaLinux/infra](https://github.com/AlmaLinux/infra)
 
-The Infrastructure SIG uses the [Infrastructure](https://chat.almalinux.org/almalinux/channels/infrastructure) chat channel and the [Infrastructure mailing list](https://lists.almalinux.org/mailman3/lists/infra.lists.almalinux.org/) for communication.
+## Recent Contributions
 
-**Where and when we meet**
+- Migrated CI jobs to GitHub Actions and internal runners
+- Improved rsync mirror automation and global CDN fallback
+- Added build support for AlmaLinux 10
+- Supported LiveMedia and Cloud SIGs with automated pipelines
 
-We don't currently hold regular meetings, but work asynchronously in mattermost to accomplish our goals. 
+## Help Wanted
 
-## Activities, projects, and deliverables
+- Engineers with knowledge of Ansible, Terraform, or CI/CD tools
+- Contributors to monitor and improve uptime, metrics, and observability
+- Developers to contribute to automation scripts and tooling
 
-* [Infrastructure Ansible Playbook](https://github.com/almalinux/infra-ansible)
-* Mirror infrastructure: [AlmaLinux/mirrors](https://github.com/AlmaLinux/mirrors)
-* Official mirrors:
-  * Official rsync mirror: https://rsync.repo.almalinux.org
-  * Azure Mirrors: 
-[East US](https://github.com/AlmaLinux/mirrors/blob/master/mirrors.d/eastus.azure.repo.almalinux.org.yml),
-[West US](https://github.com/AlmaLinux/mirrors/blob/master/mirrors.d/westus2.azure.repo.almalinux.org.yml),
-[Southeast Asia](https://github.com/AlmaLinux/mirrors/blob/master/mirrors.d/southeastasia.azure.repo.almalinux.org.yml),
-[Germany West/Central](https://github.com/AlmaLinux/mirrors/blob/master/mirrors.d/germanywestcentral.azure.repo.almalinux.org.yml)
-  * [AWS CloudFront Mirror](https://github.com/AlmaLinux/mirrors/blob/master/mirrors.d/aws.repo.almalinux.org.yml)
-  * [repo.almalinux.org](https://github.com/AlmaLinux/mirrors/blob/master/mirrors.d/repo.almalinux.org.yml)
-* [AlmaLinux Account Services](https://accounts.almalinux.org)
-* [Mattermost Chat](https://chat.almalinux.org)
-* [Mailing Lists](https://lists.almalinux.org)
-* Infrastructure Monitoring System (Zabbix)
-* DNS
-* Servers/basic infrastructure for all other services including but not limited to:
-  * [almalinux.org](https://almalinux.org)
-  * [wiki](https://wiki.almalinux.org)
-  * [git](https://git.almalinux.org)
-  * [Package Evolution Service (PES)](https://pes.almalinux.org)
-  * [Bug Reports](https://bugs.almalinux.org)
+## SIG Members
 
+* [Andrew Lukoshko](https://github.com/andrewlukoshko)
+* [Eduard Abdullin](https://github.com/eabdullin1)
+* [Other contributors](https://github.com/AlmaLinux/infra/graphs/contributors)
 
-### Help wanted
-
-* Building Ansible playbooks for maintaining internal infrastructure: https://github.com/almalinux/infra-ansible
-* much, much more.
-
-If you would like to help, please join us at [Infrastructure channel](https://chat.almalinux.org/almalinux/channels/infrastructure) 
-
-## SIG members
-
-* [Jonathan Wright](mailto:jonathan@almalinux.org) - Infrastructure Team Lead.
-  * Chat login: [jonathan](https://chat.almalinux.org/almalinux/messages/@jonathan)
-  * GitHub profile: [jonathanspw](https://github.com/jonathanspw)
-* [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - AlmaLinux OS Lead Architect.
-  * Chat login: [alukoshko](https://chat.almalinux.org/almalinux/messages/@alukoshko)
-  * GitHub profile: [andrewlukoshko](https://github.com/andrewlukoshko)
-* [Stepan Oksanichenko](mailto:soksanichenko@cloudlinux.com) - Package Evolution Service & Mirror Service Developer.
-  * Chat login: [stepan_oksanichenko](https://chat.almalinux.org/almalinux/messages/@stepan_oksanichenko)
-  * GitHub profile: [soksanichenko](https://github.com/soksanichenko)
-* [Elkhan Mammadli](mailto:elkhan@almalinux.org) - AlmaLinux OS Cloud Engineer, Cloud & Virt Team Lead.
-  * Chat login: [lkhn](https://chat.almalinux.org/almalinux/messages/@lkhn)
-  * GitHub profile: [LKHN](https://github.com/LKHN)
-* [Vasiliy Kleschov](mailto:vkleschov@almalinux.org) - Build System Team Lead.
-  * Chat login: [korulag](https://chat.almalinux.org/almalinux/messages/@korulag)
-  * GitHub profile: [Korulag](https://github.com/Korulag)
-* [Cody Robertson](mailto:crobertson@almalinux.org)
-  * Chat login: [codyr](https://chat.almalinux.org/almalinux/messages/@codyr)
-  * GitHub profile: [codyro](https://github.com/codyro)

--- a/docs/sigs/LiveMedia.md
+++ b/docs/sigs/LiveMedia.md
@@ -1,45 +1,40 @@
 ---
 title: "Live Media SIG"
 ---
+
 # Live Media SIG
 
-The Live Media Team is responsible for AlmaLinux OS Live Media.
+The Live Media SIG is responsible for creating and maintaining AlmaLinux OS Live ISO images for multiple desktop environments (GNOME, KDE, XFCE, etc.).
 
 ## How to Join
 
-Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
+Anyone is welcome to contribute! You can join our discussion on Matrix or contribute directly via GitHub.
 
-**Where we chat**
+- **Chat**: [#almalinux:matrix.org](https://matrix.to/#/#almalinux:matrix.org)
+- **GitHub Repository**: [AlmaLinux/sig-livemedia](https://github.com/AlmaLinux/sig-livemedia)
 
-The Live Media SIG uses the [SIG/LiveMedia](https://chat.almalinux.org/almalinux/channels/siglivemedia) chat channel for communication.
+## Activities and Deliverables (2025)
 
-**Where and when we meet**
+- Provide Live ISO images for AlmaLinux 9 and AlmaLinux 10
+- Maintain and test multiple spins (GNOME, KDE, XFCE)
+- Automate build and test processes using CI/CD pipelines
+- Collaborate with Infrastructure SIG to host and distribute official images
 
-We do not currently hold regular meetings, but work asynchronously in mattermost to accomplish our goals.
+**Download ISO Images**
 
-## Activities, projects, and deliverables
+- AlmaLinux 8: [repo.almalinux.org/almalinux/8/live/x86_64](https://repo.almalinux.org/almalinux/8/live/x86_64/)
+- AlmaLinux 9: [repo.almalinux.org/almalinux/9/live/x86_64](https://repo.almalinux.org/almalinux/9/live/x86_64/)
+- AlmaLinux 10: [repo.almalinux.org/almalinux/10/live/x86_64](https://repo.almalinux.org/almalinux/10/live/x86_64/) *(Work in progress)*
 
-* ISO images download link: [repo.almalinux.org/almalinux/8/live/x86_64](https://repo.almalinux.org/almalinux/8/live/x86_64/).
-* Build scripts and configuration files: [AlmaLinux/sig-livemedia](https://github.com/AlmaLinux/sig-livemedia).
+## Help Wanted
 
-### Help wanted
+- CI/CD engineers to improve build pipeline
+- Testers for verifying ISO functionality across environments
+- Technical writers for documentation and release notes
 
-* Technical writers for working on documentation.
-* Design and automate test scenarios.
+## SIG Members
 
-If you can help, please join us at [Live Media SIG on Mattermost](https://chat.almalinux.org/almalinux/channels/siglivemedia) 
-
-## SIG members
-
-* [Eduard Abdullin](mailto:eabdullin@almalinux.org) - Works on Live Media build scripts and configuration files.
-  * Chat login: [eabdullin](https://chat.almalinux.org/almalinux/messages/@eabdullin)
-  * GitHub profile: [eabdullin1](https://github.com/eabdullin1)
-* [Elkhan Mammadli](mailto:elkhan.mammadli@protonmail.com) - Works on Live Media build scripts and automation.
-  * Chat login: [lkhn](https://chat.almalinux.org/almalinux/messages/@lkhn)
-  * GitHub profile: [LKHN](https://github.com/LKHN)
-* [Yuriy Kohut](mailto:ykohut@almalinux.org) - Works on Live Media build scripts and configuration files.
-  * Chat login: [ykohut](https://chat.almalinux.org/almalinux/messages/@ykohut)
-  * GitHub profile: [yuravk](https://github.com/yuravk)
-* [Andrew Lukoshko](mailto:alukoshko@almalinux.org) - The AlmaLinux OS Lead Architect.
-  * Chat login: [alukoshko](https://chat.almalinux.org/almalinux/messages/@alukoshko)
-  * GitHub profile: [andrewlukoshko](https://github.com/andrewlukoshko)
+- Eduard Abdullin ([GitHub](https://github.com/eabdullin1))
+- Elkhan Mammadli ([GitHub](https://github.com/LKHN))
+- Yuriy Kohut ([GitHub](https://github.com/yuravk))
+- Andrew Lukoshko – AlmaLinux OS Lead Architect ([GitHub](https://github.com/andrewlukoshko))

--- a/docs/sigs/Marketing.md
+++ b/docs/sigs/Marketing.md
@@ -1,87 +1,51 @@
 ---
 title: "Marketing SIG"
 ---
+
 # Marketing SIG
 
-The Marketing team is responsible for AlmaLinux marketing and outreach efforts. Marketing is often an overlooked or eschewed term in open source, but without marketing efforts it's a whole lot harder for your audience to find you. We try to make it easy for the users who need a free enterprise linux distribution to find us.
+The Marketing SIG is responsible for promoting AlmaLinux OS, increasing awareness, and engaging with the wider Linux and open-source community.
+
+## Goals (2025)
+
+- Maintain consistent branding and visual identity across all platforms
+- Manage official communication channels (social media, forums, community events)
+- Publish updates, blog posts, release announcements, and media kits
+- Coordinate with other SIGs to publicize their achievements and releases
+- Grow the community by promoting contribution opportunities and diversity
+
+## Communication Channels
+
+We actively use the following platforms for marketing and outreach:
+
+- [X (formerly Twitter)](https://x.com/AlmaLinux)
+- [Reddit](https://www.reddit.com/r/AlmaLinux/)
+- [Discourse Forum](https://almalinux.discourse.group/)
+- [Matrix Chat](https://matrix.to/#/#almalinux:matrix.org)
+- [YouTube](https://www.youtube.com/@AlmaLinux)
+
+Old platforms such as IRC and Mattermost are no longer actively maintained.
+
+## Brand Guidelines
+
+You can find official AlmaLinux branding materials and usage instructions here:
+
+- [Logo Usage and Branding Guide](https://wiki.almalinux.org/docs/branding.html)
+- [Media Assets Repository](https://github.com/AlmaLinux/artwork)
+
+Please contact the Marketing SIG before using AlmaLinux logos in commercial materials.
+
+## Help Wanted
+
+We are looking for:
+
+- Designers with experience in FOSS branding
+- Content writers and translators
+- Social media contributors and moderators
+- People passionate about community growth and visibility
 
 ## How to Join
 
-Joining is easy! You can show up to a meeting, pick up an issue from the list by assigning it to yourself, or ask questions in chat! Not every contributor wants to be a part of the SIG, but if you do, joining is simple. 
+- **Chat**: [#almalinux:matrix.org](https://matrix.to/#/#almalinux:matrix.org)
+- **GitHub Repository**: [AlmaLinux/artwork](https://github.com/AlmaLinux/artwork)
 
-**Where we chat**
-
-We use the [~Marketing](https://chat.almalinux.org/almalinux/channels/marketing) channel for communication on the AlmaLinux mattermost server.
-
-**Where/how we meet**
-
-Meetings are every other Thursday on Google Meet at 9pm UTC. Join the Marketing channel on [chat.almalinux.org](https://chat.almalinux.org/almalinux/channels/marketing) and ask benny for the meeting invite! Our meeting notes are kept in [Google drive](https://docs.google.com/document/d/1OK8mQSU-EucCT-VdFVOd87BECmVSXIKXkG7uhLubs9o/edit#heading=h.9ynhotw081jk).
-
-## Activities, projects, and deliverables
-
-Properties that we are responsible for:
-
-* [almalinux.org](https://almalinux.org)
-* [shop.almalinux.org](https://shop.almalinux.org)
-* [events.almalinux.org](https://events.almalinux.org)
-
-We also provide content for other properties as needed by other SIGs.
-
-Other efforts that we manage: 
-
-* Event plans
-* Outreach efforts
-* Social media management
-* Press efforts
-
-### Help wanted
-
-Contributions take all kinds of shapes and sizes, and we welcome everyone! If you have expertise or time and would like to help us out, here are a few things that need help soon, and a place where you can find more information.
-
-* Mastodon automation - we use Sprout Social for scheduling ahead of time right now, but it doesn't work with mastodon! 
-* Event management and staffing -- help us expand the number of events we can join by helping us staff events local to you!
-* Content writers -- especially for the blog and social media
-* Website maintainers -- our Hugo migration is complete, but we need to clean it up
-* Graphic designers -- we have sticker ideas, but they aren't nearly as pretty as they could be!
-* Website translations -- accepted through [Weblate](https://hosted.weblate.org/projects/almalinux/website-backend/), automatically sent to the website repo for merging in. To contribute, take a look at the ["Help translating site"](/Help-translating-site.html) guide.
-
-We have tons of ideas and bugs on the [website repo](https://github.com/AlmaLinux/almalinux.org) and on [GitHub Projects](https://github.com/orgs/AlmaLinux/projects/5/views/1).
-
-## SIG members
-
-These members share responsibilities between and among each other.
-
-* [benny Vasquez](mailto:benny@almalinux.org) - SIG leader
-* [Jack Aboutboul](mailto:jack@almalinux.org) - Member
-* [Jonathan Wright](mailto:jonathan@almalinux.org) - Member 
-* [Cody Robertson](mailto:crobertson@almalinux.org) - Member 
-
-We also have a variety of folks who help us with PR, social media, and website maintenance through submissions to chat or just PRs to the [website repo](https://github.com/AlmaLinux/almalinux.org).
-
-# Marketing accounts
-
-Here is where we track the different accounts that marketing uses, and who has admin rights for them.
-
-### Various marketing-adjacent accounts
-
-* [Canva](https://canva.com) - we have a free Pro teams account - benny has admin/owner rights
-
-### Social Media Accounts
-
-We currently have a number of social media accounts that are managed by the SIG members. 
-
-#### Active accounts
-
-These accounts are actively monitored, updated, and managed by the SIG on a regular basis. 
-
-* [Mastodon (on fosstodon.org)](https://fosstodon.org/@almalinux) - password in Vaultwarden
-* [Twitter (x)](https://twitter.com/almalinux) - password in Vaultwarden
-* [Facebook](https://www.facebook.com/AlmaLinux/) - password in Vaultwarden
-* [LinkedIn](https://www.linkedin.com/company/almalinuxos/) - benny and Jack have 'owner' rights
-
-#### Inactive (placeholder) accounts
-
-These accounts are only in place to keep the name owned by us, and to point folks to our active accounts.
-
-* [Youtube](https://www.youtube.com/@almalinux6891) - benny and Jack have 'owner' rights
-* [BlueSky](bsky.app/almalinux) - password in Vaultwarden


### PR DESCRIPTION
This PR updates the Marketing SIG page to align with the current outreach strategy as of 2025.

- Replaces outdated references to IRC and Mattermost
- Adds active platforms including X (Twitter), Reddit, Matrix, and Discourse
- Clarifies branding usage guidelines and links
- Highlights open roles for contributors

This ensures consistent messaging and supports further international and community growth efforts.
