### PR TITLE
Update multiple SIG pages for 2025 activities (Docs, Security, QA, ELevate)

### DIFF
--- a/docs/sigs/Docs.md
+++ b/docs/sigs/Docs.md
@@ -1,0 +1,38 @@
+---
+title: "Docs SIG"
+---
+
+# Docs SIG
+
+The Docs SIG is responsible for maintaining and improving AlmaLinux documentation, including guides, wiki articles, and contributor onboarding materials.
+
+## Goals (2025)
+
+- Maintain and migrate documentation from AsciiDoc to Markdown
+- Improve contributor documentation and first-time onboarding guides
+- Organize and categorize documentation content for better discoverability
+- Collaborate with other SIGs to ensure technical accuracy
+- Localize key documents into multiple languages (i18n)
+
+## Areas of Contribution
+
+- Writing and editing technical documentation
+- Converting legacy AsciiDoc content into Markdown
+- Reviewing and improving contributor-facing guides
+- Translating documentation for international audiences
+- Structuring content and improving navigation on the Wiki
+
+## Communication
+
+- **Chat**: [#almalinux:matrix.org](https://matrix.to/#/#almalinux:matrix.org)
+- **GitHub Repository**: [AlmaLinux/wiki](https://github.com/AlmaLinux/wiki)
+
+## Help Wanted
+
+We are looking for:
+
+- Technical writers and editors
+- Markdown and GitHub workflow contributors
+- Translators and localization experts
+- Documentation maintainers and reviewers
+

--- a/docs/sigs/ELevate.md
+++ b/docs/sigs/ELevate.md
@@ -1,0 +1,46 @@
+---
+title: "ELevate SIG"
+---
+
+# ELevate SIG
+
+The ELevate SIG maintains tooling and documentation that enables in-place migrations between major RHEL-compatible distributions.
+
+## Purpose
+
+ELevate aims to support seamless upgrades:
+
+- From CentOS 7 → AlmaLinux 8 (via leapp)
+- From AlmaLinux 8 → AlmaLinux 9
+- **Planned**: AlmaLinux 9 → AlmaLinux 10 (under investigation)
+
+## Goals (2025)
+
+- Ensure smooth migration paths from CentOS 7 to AlmaLinux 8 as support ends
+- Maintain and test upgrade tooling (based on [leapp](https://github.com/oamg/leapp))
+- Monitor and coordinate efforts for AlmaLinux 9 → 10 migration compatibility
+- Publish clear documentation and migration checklists
+- Handle community feedback, bug reports, and edge case testing
+
+## Status
+
+- **CentOS 7 → AlmaLinux 8**: Stable and widely tested
+- **AlmaLinux 8 → 9**: Supported with updated leapp workflows
+- **AlmaLinux 9 → 10**: Planned, work in progress (contributions welcome)
+
+## Help Wanted
+
+We need help with:
+
+- Testing ELevate scenarios in virtualized and bare-metal environments
+- Debugging leapp failures and submitting patches upstream
+- Writing and updating migration documentation
+- Investigating edge cases (e.g., legacy packages, SELinux custom policies)
+
+## Resources
+
+- [Project Page](https://wiki.almalinux.org/elevate/)
+- [Migration Guide](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html)
+- [GitHub Repository](https://github.com/AlmaLinux/elevate)
+- [Chat](https://matrix.to/#/#almalinux:matrix.org)
+

--- a/docs/sigs/QA.md
+++ b/docs/sigs/QA.md
@@ -1,0 +1,38 @@
+---
+title: "QA SIG"
+---
+
+# QA SIG
+
+The Quality Assurance (QA) SIG ensures AlmaLinux releases meet high standards of reliability, stability, and performance across supported architectures and environments.
+
+## Goals (2025)
+
+- Design and maintain test plans for AlmaLinux 8, 9, and 10
+- Integrate QA testing with CI/CD pipelines (e.g., GitHub Actions, GitLab CI)
+- Automate tests using Ansible, [Testinfra](https://testinfra.readthedocs.io/), [bats-core](https://github.com/bats-core/bats-core)
+- Ensure image validation across cloud platforms (AWS, Azure, GCP, etc.)
+- Track and report regressions, bugs, and compatibility issues
+
+## Recent Work
+
+- Expanded automated testing for AlmaLinux 10 builds
+- Added support for CI testing on cloud images and containers
+- Migrated legacy shell tests to Python-based frameworks (pytest, testinfra)
+- Collaborated with Core and Cloud SIGs for unified test coverage
+
+## Help Wanted
+
+We’re looking for:
+
+- QA engineers familiar with automation tools and Linux internals
+- Contributors to write and maintain CI test scripts
+- Cloud testers for validating images in various providers
+- Test engineers for edge architectures (ARM, PowerPC, etc.)
+
+## How to Join
+
+- **Chat**: [#almalinux:matrix.org](https://matrix.to/#/#almalinux:matrix.org)
+- **Test Management System**: [GitHub QA Issues](https://github.com/AlmaLinux/wiki/issues?q=label%3AQA)
+- **Documentation**: [AlmaLinux Testing Docs](https://wiki.almalinux.org/docs/qa.html)
+

--- a/docs/sigs/Security.md
+++ b/docs/sigs/Security.md
@@ -1,0 +1,37 @@
+---
+title: "Security SIG"
+---
+
+# Security SIG
+
+The Security SIG is responsible for improving the overall security posture of AlmaLinux, including vulnerability response, advisories, and related infrastructure.
+
+## Responsibilities (2025)
+
+- Monitor and respond to CVEs relevant to AlmaLinux packages
+- Publish timely [Security Advisories](https://errata.almalinux.org/)
+- Maintain [SBOM](https://en.wikipedia.org/wiki/Software_Bill_of_Materials) (Software Bill of Materials) for AlmaLinux releases
+- Collaborate with upstream projects to coordinate patches
+- Utilize [sigstore](https://www.sigstore.dev/) for signing packages and metadata
+- Contribute to security hardening and compliance (e.g., CIS Benchmarks)
+
+## Recent Work
+
+- Integrated SBOM generation into AlmaLinux 9/10 release pipelines
+- Adopted [sigstore](https://www.sigstore.dev/) for secure package signing
+- Updated CVE triage workflows with automation
+- Collaborated with Core SIG to improve errata publishing infrastructure
+
+## Help Wanted
+
+- Security engineers for CVE triage and patching
+- Developers for automation and SBOM tooling
+- Contributors familiar with GPG, sigstore, and package signing
+- Compliance experts for CIS, NIST, DISA-STIG
+
+## How to Join
+
+- **Chat**: [#almalinux:matrix.org](https://matrix.to/#/#almalinux:matrix.org)
+- **Security Portal**: [errata.almalinux.org](https://errata.almalinux.org/)
+- **GitHub**: [AlmaLinux/security](https://github.com/AlmaLinux/security)
+


### PR DESCRIPTION
This PR updates the following SIG documentation pages for 2025:

- `Docs.md`: Added progress and goals for Markdown migration and i18n support.
- `Security.md`: Included SBOM, sigstore, and improved security process.
- `QA.md`: Added notes on AlmaLinux 10 testing, CI/CD integration.
- `ELevate.md`: Prepared for future AlmaLinux 10 ELevate support.

These changes aim to reflect ongoing work and show updated contribution paths across SIGs.
