### PR TITLE
Enable last-updated plugin in deployment workflow

### DIFF
--- a/.github/workflows/deploy-gh_pages.yml
+++ b/.github/workflows/deploy-gh_pages.yml
@@ -11,12 +11,27 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
+      with:
+        # fetch all commits to get last updated time or other git log info
+        fetch-depth: 0
 
-    - name: Build and Deploy
-      uses: jenkey2011/vuepress-deploy@master
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
+    - name: Install deps
+      run: yarn
+
+    - name: Build VuePress site
+      run: yarn docs:build
+
+    # please check out the docs of the workflow for more details
+    # @see https://github.com/crazy-max/ghaction-github-pages
+    - name: Deploy to GitHub Pages
+      uses: crazy-max/ghaction-github-pages@v4
+      with:
+        target_branch: gh-pages
+        build_dir: docs/.vuepress/dist
       env:
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        TARGET_REPO: AlmaLinux/wiki
-        TARGET_BRANCH: gh-pages
-        BUILD_SCRIPT: yarn && yarn docs:build
-        BUILD_DIR: docs/.vuepress/dist/
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Replaced jenkey2011/vuepress-deploy with crazy-max/ghaction-github-pages to support the recently added last-updated plugin.
The new workflow is based on the VuePress v2 deployment guide: https://vuepress.github.io/guide/deployment.html#github-pages

Bug: https://github.com/jenkey2011/vuepress-deploy/issues/36
Related: https://github.com/AlmaLinux/wiki/pull/595