### PR TITLE
Update ELevate documentation

### DIFF
--- a/docs/elevate/Changelog.md
+++ b/docs/elevate/Changelog.md
@@ -2,11 +2,32 @@
 title: "ELevate Changelog"
 ---
 
-###### last updated: 2025-08-20
+###### last updated: 2025-11-03
 
 # ELevate Changelog
 
 **Note**, this changelog only includes updates made from 2024-09-24 onwards, and does not include any changes made prior to this date.
+
+## 2025-11-03
+
+Released to Stable:
+
+#### PES data updates
+
+- New Vendor **elevate** - ELevate enables upgrades between major versions of RHEL derivatives. Enabled for all upgrade paths
+- Enable Vendors for 9 to 10 upgrade:
+  - **nginx**
+  - **kernelcare**
+  - **mariadb** (without MaxScale and Tools repositories)
+  - **imunify**
+  - **imunify360-alt-php**
+- Vendor **kernelcare** use `el-sig202505` repository
+- Vendor **imunify**: update rpm GPG key, correct EL9 `imunify360-testing` repository baseurl, update packages SIGs
+- Vendor **imunify360-alt-php** update rpm GPG key, update packages SIGs
+
+#### ELevate release package
+
+- Use `$releasever` instead of `%{rhel}` in `baseurl`
 
 ## 2025-08-20
 

--- a/docs/elevate/Contribution-guide.md
+++ b/docs/elevate/Contribution-guide.md
@@ -2,7 +2,7 @@
 title: "ELevate Contribution Guide"
 ---
 
-###### last updated: 2025-06-05
+###### last updated: 2025-11-03
 
 # Contribute to the ELevate project
 
@@ -17,12 +17,13 @@ Currently, the ELevate project supports the following of 3rd party repositories:
 
 - EPEL support is currently available for upgrades to AlmaLinux OS only. **Note**, that the support works only for those packages from EL 9 that are currently available for EL 10. Unavailable packages from EL 9 will remain on the system after the upgrade.
 - Docker CE - for all supported operating systems.
-- MariaDB - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
-- nginx - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- MariaDB - for supported operating systems.
+- nginx - for supported operating systems.
 - PostgreSQL - for all supported operating systems.
-- Imunify - for upgrades to EL 8.
-- KernelCare - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- Imunify - for upgrades to EL 8 and EL 10.
+- KernelCare - for supported operating systems.
 - TuxCare - for all supported operating systems.
+- ELevate - for all supported operating systems.
 
 This guide provides steps to integrate 3rd party repository packages into the ELevate upgrade process.
 :::danger

--- a/docs/elevate/ELevate-NG-testing-guide.md
+++ b/docs/elevate/ELevate-NG-testing-guide.md
@@ -2,7 +2,7 @@
 title: "ELevate NG Testing Guide"
 ---
 
-###### last updated: 2025-07-03
+###### last updated: 2025-11-03
 
 # ELevate NG Testing Guide
 
@@ -14,12 +14,13 @@ The ELevate NG supports a number of 3rd party repositories:
 
 - EPEL support is currently available for upgrades to AlmaLinux OS only. **Note**, that the support works only for those packages from EL 9 that are currently available for EL 10. Unavailable packages from EL 9 will remain on the system after the upgrade.
 - Docker CE - for all supported operating systems.
-- MariaDB - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
-- nginx - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- MariaDB - for supported operating systems.
+- nginx - for supported operating systems.
 - PostgreSQL - for all supported operating systems.
-- Imunify - for upgrades to EL 8.
-- KernelCare - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- Imunify - for upgrades to EL 8 and EL 10.
+- KernelCare - for supported operating systems.
 - TuxCare - for all supported operating systems.
+- ELevate - for all supported operating systems.
 
 :::tip
 You can add more 3rd party repositories support. See more on the [Contribute](/elevate/Contribution-guide) page.
@@ -143,12 +144,103 @@ EL7 to EL8 upgrades aren't supported by [leapp-repository upstream](https://gith
 
 Please follow the [ELevating CentOS 7 to AlmaLinux 10](/elevate/ELevating-CentOS7-to-AlmaLinux-10) guide to upgrade CentOS7 to AlmaLinux 8.
 
+## Prepare the system for upgrading to AlmaLinux 9
+
+:::warning
+Skip these steps if your system was NOT upgraded from EL 7.
+:::
+
+When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to prepare your system for upgrading to AlmaLinux 9:
+
+- Navigate to the **/etc/** directory and use an editor of your choice to edit the **yum.conf** file. You need to remove everything from the **exclude** line especially that refers to elevate or leapp.
+
+  ##### An example of yum.conf file:
+
+  ```bash
+  [main]
+  gpgcheck=1
+  installonly_limit=3
+  clean_requirements_on_remove=True
+  best=True
+  skip_if_unavailable=False
+  exclude=python2-leapp,snactor,leapp-upgrade-el7toel8,leapp
+  ```
+
+- Then navigate to the _/etc/dnf/_ directory and use an editor of your choice to do the same in the **dnf.conf** file.
+- Now you can remove/manually upgrade packages left from CentOS 7 without any conflicts.
+- Check packages left from CentOS 7:
+
+  ```bash
+  rpm -qa | grep el7
+  ```
+
+  An example output with a list of packages:
+
+  ```bash
+  leapp-data-almalinux-0.5-1.el7.20241127.noarch
+  leapp-0.18.0-2.el7.noarch
+  kernel-3.10.0-1160.119.1.el7.x86_64
+  python2-leapp-0.18.0-2.el7.noarch
+  leapp-upgrade-el7toel8-0.21.0-5.el7.elevate.4.noarch
+  kernel-3.10.0-1127.el7.x86_64
+  ```
+
+  As mentioned above, consider removing these packages or upgrading them manually to proceed with upgrade to AlmaLinux 9.
+
+  :::tip
+  If you face difficulties while removing the packages, the following command might help you:
+
+  ```bash
+  sudo rpm -e --nodeps <package_name>
+  ```
+
+  :::
+
+- You can also check for the packages left from the upgrade process and remove them:
+
+  ```bash
+  rpm -qa | grep elevate
+  rpm -qa | grep leapp
+  ```
+
+- Check whether you have the _/root/tmp_leapp_py3_ directory created and if so delete it.
+
+  ```bash
+  sudo rm -fr /root/tmp_leapp_py3
+  ```
+
+- Clean up your machine.
+
+  ```bash
+  sudo dnf clean all
+  ```
+
+- You may also have to remove old RSA/SHA1 GPG keys. List the keys:
+
+  ```bash
+  rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n'
+  ```
+
+  To remove them, use use the `rpm -e` command:
+
+  ```bash
+  sudo rpm -e [keyname]
+  ```
+
+  After these preparations are completed, you can upgrade your AlmaLinux 8 machine to AlmaLinux 9.
+
 ## Upgrading AlmaLinux 8 to AlmaLinux 9
 
 - Install ELevate NG version repo config for AlmaLinux8:
 
   ```bash
   sudo curl -o /etc/yum.repos.d/elevate-ng.repo https://repo.almalinux.org/elevate/testing/elevate-ng-el$(rpm -E %rhel).repo
+  ```
+
+- Import ELevate GPG key:
+
+  ```bash
+  sudo rpm --import https://repo.almalinux.org/elevate/RPM-GPG-KEY-ELevate
   ```
 
 - Install leapp packages and upgrade data for AlmaLinux which is target OS:
@@ -217,6 +309,10 @@ Please follow the [ELevating CentOS 7 to AlmaLinux 10](/elevate/ELevating-CentOS
   ```
 
 ## Prepare the system for upgrade to AlmaLinux 10
+
+:::warning
+Skip these steps if your system was NOT upgraded from EL 8.
+:::
 
 When successfully upgraded to AlmaLinux 9 OS, consider performing these steps to prepare your system for upgrading to AlmaLinux 10:
 
@@ -287,10 +383,6 @@ When successfully upgraded to AlmaLinux 9 OS, consider performing these steps to
 After these preparations are completed, you can upgrade your AlmaLinux 9 machine to AlmaLinux 10.
 
 ## Upgrading AlmaLinux 9 to AlmaLinux 10
-
-:::warning
-This upgrade is currently in development and testing. The main goals are to deliver working `leapp-data` and `leapp-repository` packages needed for the upgrade and to be able to upgrade to AlmaLinux OS 10 successfully. This upgrade is not recommended for production machines.
-:::
 
 :::tip
 These steps can also be used to perform the upgrade from CentOS Stream 9 to CentOS Stream 10. The only difference is the `leapp-data` package.

--- a/docs/elevate/ELevate-quickstart-guide.md
+++ b/docs/elevate/ELevate-quickstart-guide.md
@@ -2,7 +2,7 @@
 title: "ELevate Quickstart Guide"
 ---
 
-###### last updated: 2025-06-06
+###### last updated: 2025-11-03
 
 # ELevate Quickstart Guide
 
@@ -20,12 +20,13 @@ The ELevate project supports a number of 3rd party repositories:
 
 - EPEL support is currently available for upgrades to AlmaLinux OS only. **Note**, that the support works only for those packages from EL 9 that are currently available for EL 10. Unavailable packages from EL 9 will remain on the system after the upgrade.
 - Docker CE - for all supported operating systems.
-- MariaDB - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
-- nginx - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- MariaDB - for supported operating systems.
+- nginx - for supported operating systems.
 - PostgreSQL - for all supported operating systems.
-- Imunify - for upgrades to EL 8.
-- KernelCare - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- Imunify - for upgrades to EL 8 and EL 10.
+- KernelCare - for supported operating systems.
 - TuxCare - for all supported operating systems.
+- ELevate - for all supported operating systems.
 
 :::tip
 You can contribute to the project and add more 3rd party repositories support. See more on the [Contribute](/elevate/Contribution-guide) page.

--- a/docs/elevate/ELevate-testing-guide.md
+++ b/docs/elevate/ELevate-testing-guide.md
@@ -2,7 +2,7 @@
 title: "ELevate Testing Guide"
 ---
 
-###### last updated: 2025-06-09
+###### last updated: 2025-11-03
 
 # ELevate Testing Guide
 
@@ -21,12 +21,13 @@ The ELevate Project supports a number of 3rd party repositories:
 
 - EPEL support is currently available for upgrades to AlmaLinux OS only. **Note**, that the support works only for those packages from EL 9 that are currently available for EL 10. Unavailable packages from EL 9 will remain on the system after the upgrade.
 - Docker CE - for all supported operating systems.
-- MariaDB - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
-- nginx - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- MariaDB - for supported operating systems.
+- nginx - for supported operating systems.
 - PostgreSQL - for all supported operating systems.
-- Imunify - for upgrades to EL 8.
-- KernelCare - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- Imunify - for upgrades to EL 8 and EL 10.
+- KernelCare - for supported operating systems.
 - TuxCare - for all supported operating systems.
+- ELevate - for all supported operating systems.
 
 :::tip
 You can contribute to the project and add more 3rd party repositories support. See more on the [Contribute](/elevate/Contribution-guide) page.
@@ -116,6 +117,10 @@ ELevate currently does not support the [Raspberry Pi images](https://github.com/
 
 ## Prepare the system for upgrading to AlmaLinux 9
 
+:::warning
+Skip these steps if your system was NOT upgraded from EL 7.
+:::
+
 When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to prepare your system for upgrading to AlmaLinux 9:
 
 - Navigate to the **/etc/** directory and use an editor of your choice to edit the **yum.conf** file. You need to remove everything from the **exclude** line especially that refers to elevate or leapp.
@@ -203,6 +208,12 @@ When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to
   sudo curl https://repo.almalinux.org/elevate/testing/elevate-testing.repo -o /etc/yum.repos.d/elevate-testing.repo
   ```
 
+- Import ELevate GPG key:
+
+  ```bash
+  sudo rpm --import https://repo.almalinux.org/elevate/RPM-GPG-KEY-ELevate
+  ```
+
 - Install leapp packages and upgrade data for AlmaLinux:
 
   ```bash
@@ -267,6 +278,10 @@ When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to
   ```
 
 ## Prepare the system for upgrade to AlmaLinux 10
+
+:::warning
+Skip these steps if your system was NOT upgraded from EL 8.
+:::
 
 When successfully upgraded to AlmaLinux 9 OS, consider performing these steps to prepare your system for upgrading to AlmaLinux 10:
 
@@ -354,6 +369,12 @@ The only difference is the `leapp-data` package.
 
   ```bash
   sudo curl https://repo.almalinux.org/elevate/testing/elevate-testing.repo -o /etc/yum.repos.d/elevate-testing.repo
+  ```
+
+- Import ELevate GPG key:
+
+  ```bash
+  sudo rpm --import https://repo.almalinux.org/elevate/RPM-GPG-KEY-ELevate
   ```
 
 - Install leapp packages and upgrade data for AlmaLinux which is target OS:

--- a/docs/elevate/ELevating-CentOS7-to-AlmaLinux-10.md
+++ b/docs/elevate/ELevating-CentOS7-to-AlmaLinux-10.md
@@ -2,7 +2,7 @@
 title: "ELevating CentOS 7 to AlmaLinux 10"
 ---
 
-###### last updated: 2025-06-09
+###### last updated: 2025-11-03
 
 # ELevating CentOS 7 to AlmaLinux 10
 
@@ -17,12 +17,13 @@ The ELevate project supports a number of 3rd party repositories:
 
 - EPEL support is currently available for upgrades to AlmaLinux OS only. **Note**, that the support works only for those packages from EL 9 that are currently available for EL 10. Unavailable packages from EL 9 will remain on the system after the upgrade.
 - Docker CE - for all supported operating systems.
-- MariaDB - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
-- nginx - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- MariaDB - for supported operating systems.
+- nginx - for supported operating systems.
 - PostgreSQL - for all supported operating systems.
-- Imunify - for upgrades to EL 8.
-- KernelCare - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10
+- Imunify - for upgrades to EL 8 and EL 10.
+- KernelCare - for supported operating systems.
 - TuxCare - for all supported operating systems.
+- ELevate - for all supported operating systems.
 
 :::tip
 You can add more 3rd party repositories support. See more on the [Contribute](/elevate/Contribution-guide) page.
@@ -110,6 +111,10 @@ ELevate currently does not support the [Raspberry Pi images](https://github.com/
   ```
 
 ## Prepare the system for upgrade to AlmaLinux 9
+
+:::warning
+Skip these steps if your system was NOT upgraded from EL 7.
+:::
 
 When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to prepare your system for upgrading to AlmaLinux 9:
 
@@ -265,6 +270,10 @@ When successfully upgraded to AlmaLinux 8 OS, consider performing these steps to
   ```
 
 ## Prepare the system for upgrade to AlmaLinux 10
+
+:::warning
+Skip these steps if your system was NOT upgraded from EL 8.
+:::
 
 When successfully upgraded to AlmaLinux 9 OS, consider performing these steps to prepare your system for upgrading to AlmaLinux 10:
 

--- a/docs/elevate/README.md
+++ b/docs/elevate/README.md
@@ -2,7 +2,7 @@
 title: "About ELevate project"
 ---
 
-###### last updated: 2025-06-06
+###### last updated: 2025-11-03
 
 # About the project
 
@@ -22,12 +22,13 @@ The ELevate project supports a number of 3rd party repositories:
 
 - EPEL support is currently available for upgrades to AlmaLinux OS only. **Note**, that the support works only for those packages from EL 9 that are currently available for EL 10. Unavailable packages from EL 9 will remain on the system after the upgrade.
 - Docker CE - for all supported operating systems.
-- MariaDB - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
-- nginx - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- MariaDB - for supported operating systems.
+- nginx - for supported operating systems.
 - PostgreSQL - for all supported operating systems.
-- Imunify - for upgrades to EL 8.
-- KernelCare - for supported operating systems excluding AlmaLinux 10, AlmaLinux Kitten 10, and CentOS Stream 10.
+- Imunify - for upgrades to EL 8 and EL 10.
+- KernelCare - for supported operating systems.
 - TuxCare - for all supported operating systems.
+- ELevate - for all supported operating systems.
 
 :::tip
 You can contribute to the project and add more 3rd party repositories support. See more on the [Contribute](/elevate/Contribution-guide) page.


### PR DESCRIPTION
Update Changelog as of **2025-11-03**.
Update vendors list in _Contribution Guide_, _README_, _NG Testing Guide_, _Quickstart Guide_, _Testing Guide_ and _ELevating CentOS 7 to AlmaLinux 10_. 
Add warning, to the "_Prepare the system for upgrading to ..._" chapters, to proceed with certain steps if incremental upgrade only.
Add "_Import ELevate GPG key_" step where it is missed.
Update `elevate-release` package to use `$releasever` instead of `%{rhel}` in `baseurl`