### PR TITLE
Adding the Media & Entertainment SIG to the sidebar menu

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -156,6 +156,7 @@ module.exports = {
             children: [
               "/sigs/Atomic",
               "/sigs/Build-System",
+              "/sigs/Certification",
               "/sigs/Cloud",
               "/sigs/Core",
               "/sigs/HPCandAI",
@@ -166,8 +167,8 @@ module.exports = {
                 path: "/sigs/Marketing",
                 children: ["/sigs/marketing/indico"],
               },
+              "/sigs/MediaAndEntertainmentSIG",
               "/sigs/Migration",
-              "/sigs/Certification",
               "/sigs/ProcessForCreatingNewSIG",
             ],
           },


### PR DESCRIPTION
Looks like I missed this step the other day.

also fixed the order so they're alphabetical again.