### PR TITLE
Add ALESCo meeting minutes for April 09, 2026

### DIFF
--- a/docs/alesco/meeting-minutes.md
+++ b/docs/alesco/meeting-minutes.md
@@ -6,6 +6,7 @@ Each meeting of ALESCo is public, and future meetings can be found on [events.al
 
 # ALESCo Meeting Minutes
 
+- [April 09, 2026](/alesco/meeting-minutes/2026-04-09)
 - [March 12, 2026](/alesco/meeting-minutes/2026-03-12)
 - [February 12, 2026](/alesco/meeting-minutes/2026-02-12)
 - [January 08, 2026](/alesco/meeting-minutes/2026-01-08)

--- a/docs/alesco/meeting-minutes/2026-04-09.md
+++ b/docs/alesco/meeting-minutes/2026-04-09.md
@@ -1,0 +1,39 @@
+# ALESCo Meeting Minutes (2026-04-09)
+
+Minutes recorded by Andrew Lukoshko.
+
+Edited by Andrew Lukoshko for publishing.
+
+## Members
+
+### ALESCo Member Attendees
+
+- Andrew Lukoshko
+- Ben Thomas
+- Jonathan Wright
+- Neal Gompa
+
+### Unable to attend
+
+### Board Attendees
+
+### Community Attendees
+
+## Decisions Adopted
+
+- Unanimously approved including the [proc: fix a dentry lock race between release_task and lookup](https://github.com/torvalds/linux/commit/d919a1e79bac890421537cf02ae773007bf55e6b) upstream kernel patch for AlmaLinux 9.
+
+## Minutes
+
+Discussed [RFC: Provide Secure Boot-Signed Alternative Kernels](https://github.com/AlmaLinux/ALESCo/pull/15)
+
+- The RFC author has abandoned the effort. We are reaching out to people who have expressed interest in this feature to find someone to pick it up and continue the work.
+
+Discussed [proc: fix a dentry lock race between release_task and lookup](https://github.com/torvalds/linux/commit/d919a1e79bac890421537cf02ae773007bf55e6b) upstream kernel patch
+
+- ALESCo unanimously approved including this patch for AlmaLinux 9. Andrew Lukoshko will prepare a testing build.
+
+Discussed policy for adding new ALESCo members:
+
+- Neal Gompa needs an extra week to finish the questionnaire.
+

--- a/docs/alesco/meeting-minutes/2026-04-09.md
+++ b/docs/alesco/meeting-minutes/2026-04-09.md
@@ -36,4 +36,3 @@ Discussed [proc: fix a dentry lock race between release_task and lookup](https:/
 Discussed policy for adding new ALESCo members:
 
 - Neal Gompa needs an extra week to finish the questionnaire.
-


### PR DESCRIPTION
## Summary

- Add ALESCo meeting minutes for the April 09, 2026 meeting
- Update meeting minutes index page with new entry

## Topics Discussed

- RFC: Provide Secure Boot-Signed Alternative Kernels — reaching out to new contributors
- Approved upstream kernel patch (proc dentry lock race fix) for AlmaLinux 9
- Policy for adding new ALESCo members — questionnaire in progress