### PR TITLE
9.8-beta: document ALESCo-approved kernel dentry race fix

### DIFF
--- a/docs/release-notes/9.8-beta.md
+++ b/docs/release-notes/9.8-beta.md
@@ -81,6 +81,10 @@ Please report any issues you may encounter during tests on the [AlmaLinux Bug Tr
   - cmake 3.31.8
   - sudo 1.9.17p2
 
+### Deviations from RHEL 9
+
+- AlmaLinux OS 9.8 includes an earlier backport of the upstream kernel fix [d919a1e79bac](https://github.com/torvalds/linux/commit/d919a1e79bac890421537cf02ae773007bf55e6b) ("proc: fix a dentry lock race between release_task and lookup"), which addresses excessive CPU consumption by `systemd` and `ps` during task cleanup. AlmaLinux originally submitted this fix to the CentOS Stream 9 kernel via [MR !7769](https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/merge_requests/7769), but its inclusion upstream was postponed to at least RHEL 9.9. The [AlmaLinux Engineering Steering Committee (ALESCo)](https://almalinux.org/alesco/) voted to include it in AlmaLinux 9.8 ahead of RHEL.
+
 ## Upgrade Instructions
 
 **Please do not use these update instructions on production machines unless you don't mind if something breaks** ;)


### PR DESCRIPTION
Note the early backport of upstream kernel commit d919a1e79bac ("proc: fix a dentry lock race between release_task and lookup") under a new "Deviations from RHEL 9" section, since ALESCo voted to include it in 9.8 ahead of its expected RHEL 9.9 inclusion.