### PR TITLE
Add ALESCo meeting minutes for April 23 and May 21, 2026

### DIFF
--- a/docs/alesco/meeting-minutes.md
+++ b/docs/alesco/meeting-minutes.md
@@ -6,6 +6,8 @@ Each meeting of ALESCo is public, and future meetings can be found on [events.al
 
 # ALESCo Meeting Minutes
 
+- [May 21, 2026](/alesco/meeting-minutes/2026-05-21)
+- [April 23, 2026](/alesco/meeting-minutes/2026-04-23)
 - [April 09, 2026](/alesco/meeting-minutes/2026-04-09)
 - [March 12, 2026](/alesco/meeting-minutes/2026-03-12)
 - [February 12, 2026](/alesco/meeting-minutes/2026-02-12)

--- a/docs/alesco/meeting-minutes/2026-04-23.md
+++ b/docs/alesco/meeting-minutes/2026-04-23.md
@@ -1,0 +1,44 @@
+# ALESCo Meeting Minutes (2026-04-23)
+
+Minutes recorded by Andrew Lukoshko.
+
+Edited by Andrew Lukoshko for publishing.
+
+## Members
+
+### ALESCo Member Attendees
+
+- Andrew Lukoshko
+- Ben Thomas
+- Neal Gompa
+
+### Unable to attend
+
+- Jonathan Wright
+
+### Board Attendees
+
+### Community Attendees
+
+- Keith Clemmons
+- Michel Lind
+
+## Decisions Adopted
+
+## Minutes
+
+Discussed [RFC: Provide Secure Boot-Signed Alternative Kernels](https://github.com/AlmaLinux/ALESCo/pull/15)
+
+- The RFC author has abandoned the effort. We are still reaching out to people who have expressed interest in this feature to find someone to pick it up and continue the work.
+
+Discussed [proc: fix a dentry lock race between release_task and lookup](https://github.com/torvalds/linux/commit/d919a1e79bac890421537cf02ae773007bf55e6b) upstream kernel patch
+
+- The patch has been included into the RHEL 9.8 Beta kernel.
+
+Discussed policy for adding new ALESCo members:
+
+- We are still awaiting the questionnaire from Neal Gompa.
+
+Discussed [RFC: Adding proposal for github org management](https://github.com/AlmaLinux/ALESCo/pull/16)
+
+- Decided to continue discussion in the GitHub PR.

--- a/docs/alesco/meeting-minutes/2026-05-21.md
+++ b/docs/alesco/meeting-minutes/2026-05-21.md
@@ -1,0 +1,40 @@
+# ALESCo Meeting Minutes (2026-05-21)
+
+Minutes recorded by Andrew Lukoshko.
+
+Edited by Andrew Lukoshko for publishing.
+
+## Members
+
+### ALESCo Member Attendees
+
+- Andrew Lukoshko
+- Ben Thomas
+- Jonathan Wright
+- Neal Gompa
+
+### Unable to attend
+
+### Board Attendees
+
+- benny Vasquez
+
+### Community Attendees
+
+## Decisions Adopted
+
+- Unanimously approved Neal Gompa's submitted questionnaire/proposal for the new-member onboarding process.
+
+## Minutes
+
+Discussed [RFC: Adding proposal for github org management](https://github.com/AlmaLinux/ALESCo/pull/16)
+
+- Discussion is ongoing in the GitHub PR.
+
+Discussed [RFC: Add alternative signed newer kernels](https://github.com/AlmaLinux/ALESCo/pull/15)
+
+- No change since the last meeting. We are still looking for a champion to pick up and continue this RFC.
+
+Discussed updating ALESCo policy with adding new members:
+
+- Neal Gompa's questionnaire/proposal was received and unanimously approved.


### PR DESCRIPTION
## Summary
- Adds ALESCo meeting minutes for 2026-04-23
- Adds ALESCo meeting minutes for 2026-05-21
- Updates meeting-minutes index

## Test plan
- [x] Verify both new pages render correctly
- [x] Verify index links resolve