### PR TITLE
Add ALESCo meeting minutes for June 04, 2026

### DIFF
--- a/docs/alesco/meeting-minutes.md
+++ b/docs/alesco/meeting-minutes.md
@@ -6,6 +6,7 @@ Each meeting of ALESCo is public, and future meetings can be found on [events.al
 
 # ALESCo Meeting Minutes
 
+- [June 04, 2026](/alesco/meeting-minutes/2026-06-04)
 - [May 21, 2026](/alesco/meeting-minutes/2026-05-21)
 - [April 23, 2026](/alesco/meeting-minutes/2026-04-23)
 - [April 09, 2026](/alesco/meeting-minutes/2026-04-09)

--- a/docs/alesco/meeting-minutes/2026-06-04.md
+++ b/docs/alesco/meeting-minutes/2026-06-04.md
@@ -1,0 +1,40 @@
+# ALESCo Meeting Minutes (2026-06-04)
+
+Minutes recorded by Andrew Lukoshko.
+
+Edited by Andrew Lukoshko for publishing.
+
+## Members
+
+### ALESCo Member Attendees
+
+- Andrew Lukoshko
+- Ben Thomas
+- Jonathan Wright
+- Neal Gompa
+
+### Unable to attend
+
+### Board Attendees
+
+### Community Attendees
+
+- Lance Albertson
+
+## Decisions Adopted
+
+- Unanimously voted to appoint Lance Albertson as a new ALESCo member.
+
+## Minutes
+
+Discussed [RFC: Adding proposal for github org management](https://github.com/AlmaLinux/ALESCo/pull/16)
+
+- Discussion is ongoing in the GitHub PR.
+
+Discussed [RFC: Add alternative signed newer kernels](https://github.com/AlmaLinux/ALESCo/pull/15)
+
+- Lance Albertson will be the champion to pick up and continue this RFC.
+
+Discussed adding new ALESCo members:
+
+- ALESCo voted unanimously to appoint Lance Albertson as a new ALESCo member.


### PR DESCRIPTION
Adds the ALESCo meeting minutes for June 04, 2026.

- New file: `docs/alesco/meeting-minutes/2026-06-04.md`
- Linked from the meeting minutes index