### PR TITLE
Update x86_64_v2 note: upgrades to 10/Kitten 10 supported by ELevate NG

### DIFF
--- a/docs/elevate/ELevate-NG-testing-guide.md
+++ b/docs/elevate/ELevate-NG-testing-guide.md
@@ -32,8 +32,6 @@ Currently, the following upgrade paths are available:
 
 ![image](/images/ELevateNG.webp)
 
-\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 don't support x86_64_v2 architecture.
-
 ::: warning
 ELevate currently does not support the [Raspberry Pi images](https://github.com/AlmaLinux/raspberry-pi/).
 :::

--- a/docs/elevate/ELevate-quickstart-guide.md
+++ b/docs/elevate/ELevate-quickstart-guide.md
@@ -34,7 +34,7 @@ Currently, the following upgrade paths are available:
 
 ![image](/images/ELevate.webp)
 
-\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 don't support x86_64_v2 architecture.
+\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 on the x86_64_v2 architecture are supported only by the ELevate NG version. If you need to perform such an upgrade for testing purposes, see the [ELevate NG Testing Guide](/elevate/ELevate-NG-testing-guide).
 
 ::: warning
 ELevate currently does not support the [Raspberry Pi images](https://github.com/AlmaLinux/raspberry-pi/).

--- a/docs/elevate/ELevate-testing-guide.md
+++ b/docs/elevate/ELevate-testing-guide.md
@@ -35,7 +35,7 @@ Currently, the following upgrades are available:
 
 ![image](/images/ELevate-Testing.webp)
 
-\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 don't support x86_64_v2 architecture.
+\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 on the x86_64_v2 architecture are supported only by the ELevate NG version. If you need to perform such an upgrade for testing purposes, see the [ELevate NG Testing Guide](/elevate/ELevate-NG-testing-guide).
 
 ::: warning
 ELevate currently does not support the [Raspberry Pi images](https://github.com/AlmaLinux/raspberry-pi/).

--- a/docs/elevate/ELevating-CentOS7-to-AlmaLinux-10.md
+++ b/docs/elevate/ELevating-CentOS7-to-AlmaLinux-10.md
@@ -31,7 +31,7 @@ Currently, the following upgrade paths are available:
 
 ![image](/images/ELevateNG.webp)
 
-\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 don't support x86_64_v2 architecture.
+\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 on the x86_64_v2 architecture are supported only by the ELevate NG version. If you need to perform such an upgrade for testing purposes, see the [ELevate NG Testing Guide](/elevate/ELevate-NG-testing-guide).
 
 ::: warning
 ELevate currently does not support the [Raspberry Pi images](https://github.com/AlmaLinux/raspberry-pi/).

--- a/docs/elevate/README.md
+++ b/docs/elevate/README.md
@@ -36,7 +36,7 @@ Currently, the following upgrade paths are available:
 
 ![image](/images/ELevate.webp)
 
-\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 don't support x86_64_v2 architecture.
+\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 on the x86_64_v2 architecture are supported only by the ELevate NG version. If you need to perform such an upgrade for testing purposes, see the [ELevate NG Testing Guide](/elevate/ELevate-NG-testing-guide).
 
 ## How to upgrade
 

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -48,6 +48,6 @@ Currently, the following upgrade paths are available:
 
 ![image](/images/ELevate.webp)
 
-\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 don't support x86_64_v2 architecture.
+\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 on the x86_64_v2 architecture are supported only by the ELevate NG version. If you need to perform such an upgrade for testing purposes, see the [ELevate NG Testing Guide](/elevate/ELevate-NG-testing-guide).
 
 See the [ELevate](/elevate/) section for the update steps.

--- a/docs/sigs/Migration.md
+++ b/docs/sigs/Migration.md
@@ -22,7 +22,7 @@ The project supports the following migration paths:
 
 ![image](/images/ELevate.webp)
 
-\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 don't support x86_64_v2 architecture.
+\* - Currently, upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 on the x86_64_v2 architecture are supported only by the ELevate NG version. If you need to perform such an upgrade for testing purposes, see the [ELevate NG Testing Guide](/elevate/ELevate-NG-testing-guide).
 
 ## How to Join
 


### PR DESCRIPTION
Replace the note saying upgrades to AlmaLinux 10 and AlmaLinux Kitten 10 don't support x86_64_v2 with a statement that only the ELevate NG version supports such upgrades, pointing to the ELevate NG Testing Guide. Remove the outdated note from the ELevate NG Testing Guide itself.