### PR TITLE
Add ALESCo meeting minutes for July 02 and 16, 2026

### DIFF
--- a/docs/alesco/meeting-minutes.md
+++ b/docs/alesco/meeting-minutes.md
@@ -6,6 +6,8 @@ Each meeting of ALESCo is public, and future meetings can be found on [events.al
 
 # ALESCo Meeting Minutes
 
+- [July 16, 2026](/alesco/meeting-minutes/2026-07-16)
+- [July 02, 2026](/alesco/meeting-minutes/2026-07-02)
 - [June 04, 2026](/alesco/meeting-minutes/2026-06-04)
 - [May 21, 2026](/alesco/meeting-minutes/2026-05-21)
 - [April 23, 2026](/alesco/meeting-minutes/2026-04-23)

--- a/docs/alesco/meeting-minutes/2026-07-02.md
+++ b/docs/alesco/meeting-minutes/2026-07-02.md
@@ -1,0 +1,33 @@
+# ALESCo Meeting Minutes (2026-07-02)
+
+Minutes recorded by Andrew Lukoshko.
+
+Edited by Andrew Lukoshko for publishing.
+
+## Members
+
+### ALESCo Member Attendees
+
+- Andrew Lukoshko
+- Ben Thomas
+- Jonathan Wright
+- Lance Albertson
+- Neal Gompa
+
+### Unable to attend
+
+### Board Attendees
+
+### Community Attendees
+
+## Decisions Adopted
+
+## Minutes
+
+Discussed [RFC: Adding proposal for github org management](https://github.com/AlmaLinux/ALESCo/pull/16)
+
+- No change since the last meeting.
+
+Discussed [RFC: Add alternative signed newer kernels](https://github.com/AlmaLinux/ALESCo/pull/15)
+
+- No change since the last meeting.

--- a/docs/alesco/meeting-minutes/2026-07-16.md
+++ b/docs/alesco/meeting-minutes/2026-07-16.md
@@ -1,0 +1,34 @@
+# ALESCo Meeting Minutes (2026-07-16)
+
+Minutes recorded by Andrew Lukoshko.
+
+Edited by Andrew Lukoshko for publishing.
+
+## Members
+
+### ALESCo Member Attendees
+
+- Andrew Lukoshko
+- Ben Thomas
+- Jonathan Wright
+- Lance Albertson
+
+### Unable to attend
+
+- Neal Gompa
+
+### Board Attendees
+
+### Community Attendees
+
+## Decisions Adopted
+
+## Minutes
+
+Discussed [RFC: Adding proposal for github org management](https://github.com/AlmaLinux/ALESCo/pull/16)
+
+- No change since the last meeting.
+
+Discussed [RFC: Add alternative signed newer kernels](https://github.com/AlmaLinux/ALESCo/pull/15)
+
+- The RFC was closed by its author. A new RFC will be created.


### PR DESCRIPTION
Adds meeting minutes for the ALESCo meetings held on 2026-07-02 and 2026-07-16, and links both from the meeting minutes index.

Lance Albertson is included in the ALESCo Member Attendees list on both pages, following his appointment on 2026-06-04.