### PR TITLE
Add ALESCo meeting minutes for July 30, 2026

### DIFF
--- a/docs/alesco/meeting-minutes.md
+++ b/docs/alesco/meeting-minutes.md
@@ -6,6 +6,7 @@ Each meeting of ALESCo is public, and future meetings can be found on [events.al
 
 # ALESCo Meeting Minutes
 
+- [July 30, 2026](/alesco/meeting-minutes/2026-07-30)
 - [July 16, 2026](/alesco/meeting-minutes/2026-07-16)
 - [July 02, 2026](/alesco/meeting-minutes/2026-07-02)
 - [June 04, 2026](/alesco/meeting-minutes/2026-06-04)

--- a/docs/alesco/meeting-minutes/2026-07-30.md
+++ b/docs/alesco/meeting-minutes/2026-07-30.md
@@ -1,0 +1,44 @@
+# ALESCo Meeting Minutes (2026-07-30)
+
+Minutes recorded by Andrew Lukoshko.
+
+Edited by Andrew Lukoshko for publishing.
+
+## Members
+
+### ALESCo Member Attendees
+
+- Andrew Lukoshko
+- Ben Thomas
+- Jonathan Wright
+- Lance Albertson
+- Neal Gompa
+
+### Unable to attend
+
+### Board Attendees
+
+### Community Attendees
+
+## Decisions Adopted
+
+- Unanimously voted to backport the gVNIC drivers to the AlmaLinux 9 ([bug 622](https://bugs.almalinux.org/view.php?id=622)) and 10 ([bug 621](https://bugs.almalinux.org/view.php?id=621)) kernels.
+
+## Minutes
+
+Discussed [RFC: Adding proposal for github org management](https://github.com/AlmaLinux/ALESCo/pull/16)
+
+- No change since the last meeting.
+
+Discussed the new RFC replacing the closed [RFC: Add alternative signed newer kernels](https://github.com/AlmaLinux/ALESCo/pull/15)
+
+- The new RFC is in progress and has not been filed yet.
+
+Discussed EPEL possible breaking changes:
+
+- Discussed the new versioning and stable/stream detection that will be introduced in EPEL 11, and will probably come to EPEL 10 as well. See [Looking back at EPEL 10, and forward to EPEL 11](https://discussion.fedoraproject.org/t/looking-back-at-epel-10-and-forward-to-epel-11/197373).
+
+Discussed backporting upstream GCP drivers to the AlmaLinux 9 and 10 kernels:
+
+- Google requested that the gVNIC drivers be backported to the AlmaLinux 9 and 10 kernels, tracked in [bug 622](https://bugs.almalinux.org/view.php?id=622) for AlmaLinux 9 and [bug 621](https://bugs.almalinux.org/view.php?id=621) for AlmaLinux 10.
+- ALESCo voted unanimously to backport the gVNIC drivers to AlmaLinux 9 and 10.


### PR DESCRIPTION
Adds meeting minutes for the ALESCo meeting held on 2026-07-30, and links the page from the meeting minutes index.

Note: #823 adds the July 02 and July 16 minutes and touches the same index list, so one of the two PRs will need a trivial rebase after the other merges.