### PR TITLE
Add ALESCo meeting minutes for August 13, 2026

### DIFF
--- a/docs/alesco/meeting-minutes.md
+++ b/docs/alesco/meeting-minutes.md
@@ -6,6 +6,7 @@ Each meeting of ALESCo is public, and future meetings can be found on [events.al
 
 # ALESCo Meeting Minutes
 
+- [August 13, 2026](/alesco/meeting-minutes/2026-08-13)
 - [July 30, 2026](/alesco/meeting-minutes/2026-07-30)
 - [July 16, 2026](/alesco/meeting-minutes/2026-07-16)
 - [July 02, 2026](/alesco/meeting-minutes/2026-07-02)

--- a/docs/alesco/meeting-minutes/2026-08-13.md
+++ b/docs/alesco/meeting-minutes/2026-08-13.md
@@ -1,0 +1,42 @@
+# ALESCo Meeting Minutes (2026-08-13)
+
+Minutes recorded by Andrew Lukoshko.
+
+Edited by Andrew Lukoshko for publishing.
+
+## Members
+
+### ALESCo Member Attendees
+
+- Andrew Lukoshko
+- Ben Thomas
+- Jonathan Wright
+- Lance Albertson
+- Neal Gompa
+
+### Unable to attend
+
+### Board Attendees
+
+### Community Attendees
+
+## Decisions Adopted
+
+- New ALESCo Chair - Jonathan Wright
+  - Vote was unanimous among ALESCo members with all 5 members voting for Jonathan as chair
+- The mainline-based alternative kernel will be built as the `kernel` package with no suffixes.
+- The `stream` variable will be dropped from the `almalinux-release` package in the AlmaLinux 10.3 stable release.
+
+## Minutes
+
+Chair election:
+
+- Jonathan Wright was elected as the new ALESCo Chair, unanimously, with all 5 members voting for him.
+
+Discussed the new [RFC: Build and Secure Boot-sign a mainline-based alternative kernel](https://github.com/AlmaLinux/ALESCo/pull/18), which replaces the closed [RFC: Add alternative signed newer kernels](https://github.com/AlmaLinux/ALESCo/pull/15)
+
+- It was decided to build it as the `kernel` package with no suffixes, so that enabling the repository replaces the stock kernel instead of installing a separately named one side by side.
+
+Discussed EPEL possible breaking changes:
+
+- It was decided to drop the `stream` variable from the `almalinux-release` package in the AlmaLinux 10.3 stable release.


### PR DESCRIPTION
Minutes for the 2026-08-13 ALESCo meeting.

- Jonathan Wright elected as the new ALESCo Chair (unanimous, all 5 members)
- New kernel RFC (AlmaLinux/ALESCo#18, replacing AlmaLinux/ALESCo#15): decided to build it as the `kernel` package with no suffixes
- EPEL possible breaking changes: decided to drop the `stream` variable from `almalinux-release` in the AlmaLinux 10.3 stable release

Index page updated with the new entry.